### PR TITLE
Update owner when the user is merged

### DIFF
--- a/vc_vidyo/indico_vc_vidyo/plugin.py
+++ b/vc_vidyo/indico_vc_vidyo/plugin.py
@@ -316,7 +316,10 @@ class VidyoPlugin(VCPluginMixin, IndicoPlugin):
         super(VidyoPlugin, self)._merge_users(user, merged, **kwargs)
         new_id = int(user.id)
         old_id = int(merged.id)
-        VidyoExtension.find(owned_by_id=old_id).update({'owned_by_id': new_id})
+        for ext in VidyoExtension.find(owned_by_id=old_id):
+            ext.owned_by_id = new_id
+            ext.vc_room.data['owner'] = principal_to_tuple(user)
+            flag_modified(ext.vc_room, 'data')
 
     def get_notification_cc_list(self, action, vc_room, event):
         owner = retrieve_principal(vc_room.data['owner'])


### PR DESCRIPTION
An error report led to find out that when a user is merged and before he was an owner of a VC room, the `vc_room.data['owner']` was not updated properly.