### PR TITLE
VC/Vidyo: Fix make me owner

### DIFF
--- a/vc_vidyo/indico_vc_vidyo/blueprint.py
+++ b/vc_vidyo/indico_vc_vidyo/blueprint.py
@@ -1,0 +1,25 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2015 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.from __future__ import unicode_literals
+
+from indico.core.plugins import IndicoPluginBlueprint
+
+from indico_vc_vidyo.controllers import RHVidyoRoomOwner
+
+blueprint = IndicoPluginBlueprint('vc_vidyo', 'indico_vc_vidyo')
+
+# Room management
+blueprint.add_url_rule('/event/<confId>/manage/videoconference/vidyo/<int:event_vc_room_id>/room-owner/',
+                       'set_room_owner', RHVidyoRoomOwner, methods=('POST',), defaults={'service': 'vidyo'})

--- a/vc_vidyo/indico_vc_vidyo/controllers.py
+++ b/vc_vidyo/indico_vc_vidyo/controllers.py
@@ -1,0 +1,38 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2015 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+import transaction
+from flask import flash, jsonify, session
+
+from indico.modules.vc.controllers import RHVCSystemEventBase
+from indico.modules.vc.exceptions import VCRoomError
+from indico.util.i18n import _
+
+
+class RHVidyoRoomOwner(RHVCSystemEventBase):
+    def _process(self):
+        result = {}
+        self.vc_room.vidyo_extension.owned_by_user = session.user
+        try:
+            self.plugin.update_room(self.vc_room, self.event)
+        except VCRoomError as err:
+            result['error'] = {'message': err.message}
+            result['success'] = False
+            transaction.abort()
+        else:
+            flash(_("You are now the owner of the room '{room.name}'".format(room=self.vc_room)), 'success')
+            result['success'] = True
+        return jsonify(result)

--- a/vc_vidyo/indico_vc_vidyo/plugin.py
+++ b/vc_vidyo/indico_vc_vidyo/plugin.py
@@ -25,7 +25,7 @@ from wtforms.validators import NumberRange, DataRequired
 
 from indico.core.auth import multipass
 from indico.core.config import Config
-from indico.core.plugins import IndicoPlugin, url_for_plugin, IndicoPluginBlueprint, wrap_cli_manager
+from indico.core.plugins import IndicoPlugin, url_for_plugin, wrap_cli_manager
 from indico.core import signals
 from indico.modules.vc.exceptions import VCRoomError, VCRoomNotFoundError
 from indico.modules.vc import VCPluginSettingsFormBase, VCPluginMixin
@@ -36,6 +36,7 @@ from indico.web.forms.widgets import CKEditorWidget
 
 from indico_vc_vidyo import _
 from indico_vc_vidyo.api import AdminClient, APIException, RoomNotFoundAPIException
+from indico_vc_vidyo.blueprint import blueprint
 from indico_vc_vidyo.cli import cli_manager
 from indico_vc_vidyo.forms import VCRoomForm, VCRoomAttachForm
 from indico_vc_vidyo.util import iter_user_identities, iter_extensions, update_room_from_obj
@@ -298,7 +299,7 @@ class VidyoPlugin(VCPluginMixin, IndicoPlugin):
         return client.get_room(vc_room.data['vidyo_id'])
 
     def get_blueprints(self):
-        return IndicoPluginBlueprint('vc_vidyo', __name__)
+        return blueprint
 
     def register_assets(self):
         self.register_js_bundle('vc_vidyo_js', 'js/vc_vidyo.js')

--- a/vc_vidyo/indico_vc_vidyo/static/js/vc_vidyo.js
+++ b/vc_vidyo/indico_vc_vidyo/static/js/vc_vidyo.js
@@ -11,13 +11,7 @@ $(function() {
         $.ajax({
             url: $this.data('href'),
             method: 'POST',
-            complete: IndicoUI.Dialogs.Util.progress(),
-            contentType: 'application/json',
-            data: JSON.stringify({
-                data: {
-                    owner: ['User', $('body').data('userId')]
-                }
-            })
+            complete: IndicoUI.Dialogs.Util.progress()
         }).done(function(result) {
             if (handleAjaxError(result)) {
                 return;

--- a/vc_vidyo/indico_vc_vidyo/templates/buttons.html
+++ b/vc_vidyo/indico_vc_vidyo/templates/buttons.html
@@ -1,11 +1,11 @@
-{% macro render_make_me_moderator(event, vc_room, event_vc_room, extra_classes='') %}
+{% macro render_make_me_owner(event, vc_room, event_vc_room, extra_classes='') %}
     {% if session.user != vc_room.vidyo_extension.owned_by_user and event.canModify(session.user) %}
         <a class="i-button highlight arrow {{ extra_classes }}" data-toggle="dropdown"></a>
         <ul class="dropdown" data-level="level1">
             <li>
                 <a href="#"
                    title="{% trans name=vc_room.data.owner_identity %}You will be the owner of this Vidyo room, replacing {{name}}.{% endtrans %}"
-                   class="action-make-owner" data-href="{{ url_for('vc.vc_room_modify', event_vc_room) }}">
+                   class="action-make-owner" data-href="{{ url_for_plugin('vc_vidyo.set_room_owner', event_vc_room) }}">
                     {% trans %}Make me owner{% endtrans %}
                 </a>
             </li>

--- a/vc_vidyo/indico_vc_vidyo/templates/event_buttons.html
+++ b/vc_vidyo/indico_vc_vidyo/templates/event_buttons.html
@@ -1,7 +1,7 @@
 {% extends 'vc/event_buttons.html' %}
-{% from 'vc_vidyo:buttons.html' import render_join_button, render_make_me_moderator  %}
+{% from 'vc_vidyo:buttons.html' import render_join_button, render_make_me_owner  %}
 
 {% block buttons %}
     {{ render_join_button(vc_room, "i-button-small event-service-right-button join-button") }}
-    {{ render_make_me_moderator(event, vc_room, event_vc_room, extra_classes="i-button-small") }}
+    {{ render_make_me_owner(event, vc_room, event_vc_room, extra_classes="i-button-small") }}
 {% endblock %}

--- a/vc_vidyo/indico_vc_vidyo/templates/info_box.html
+++ b/vc_vidyo/indico_vc_vidyo/templates/info_box.html
@@ -11,7 +11,7 @@
         <dd>{{ vc_room.vidyo_extension.extension }}</dd>
     {% endif %}
     {% if owner %}
-        <dt>{% trans %}Moderator{% endtrans %}</dt>
+        <dt>{% trans %}Owner{% endtrans %}</dt>
         <dd>{{ owner.full_name }}</dd>
     {% endif %}
     {% if event_vc_room.data.show_pin %}

--- a/vc_vidyo/indico_vc_vidyo/templates/manage_event_info_box.html
+++ b/vc_vidyo/indico_vc_vidyo/templates/manage_event_info_box.html
@@ -7,7 +7,7 @@
     <dd>{{ vc_room.data.description }}</dd>
     <dt>{% trans %}Extension{% endtrans %}</dt>
     <dd>{{ vc_room.vidyo_extension.extension }}</dd>
-    <dt>{% trans %}Moderator{% endtrans %}</dt>
+    <dt>{% trans %}Owner{% endtrans %}</dt>
     <dd>
         {% if owner %}
             {{ owner.full_name }}

--- a/vc_vidyo/indico_vc_vidyo/templates/management_buttons.html
+++ b/vc_vidyo/indico_vc_vidyo/templates/management_buttons.html
@@ -1,7 +1,7 @@
 {% extends 'vc/management_buttons.html' %}
-{% from 'vc_vidyo:buttons.html' import render_join_button, render_make_me_moderator  %}
+{% from 'vc_vidyo:buttons.html' import render_join_button, render_make_me_owner  %}
 
 {% block buttons %}
     {{ render_join_button(vc_room, extra_classes="icon-play") }}
-    {{ render_make_me_moderator(event_vc_room.event, vc_room, event_vc_room) }}
+    {{ render_make_me_owner(event_vc_room.event, vc_room, event_vc_room) }}
 {% endblock %}

--- a/vc_vidyo/indico_vc_vidyo/templates/vc_room_timetable_buttons.html
+++ b/vc_vidyo/indico_vc_vidyo/templates/vc_room_timetable_buttons.html
@@ -1,8 +1,8 @@
 {% extends 'vc/vc_room_timetable_buttons.html' %}
-{% from 'vc_vidyo:buttons.html' import render_join_button, render_make_me_moderator  %}
+{% from 'vc_vidyo:buttons.html' import render_join_button, render_make_me_owner  %}
 {% set vc_room = event_vc_room.vc_room %}
 
 {% block buttons %}
     {{ render_join_button(vc_room, "i-button-small event-service-right-button join-button") }}
-    {{ render_make_me_moderator(event, vc_room, event_vc_room, extra_classes="i-button-small") }}
+    {{ render_make_me_owner(event, vc_room, event_vc_room, extra_classes="i-button-small") }}
 {% endblock %}


### PR DESCRIPTION
 - make me owner now sets the owner identity correctly in the vc_room data
 - fixes #9
 - "make me owner" relies on the connected user rather than a user id provided by the client
 - renames the macro `make_me_moderator` to `make_me_owner`
 - small modification in a flash message in Indico for consistency: indico/indico#1879