### PR TITLE
VC/Vidyo: use zeep instead of suds

### DIFF
--- a/vc_vidyo/indico_vc_vidyo/api/cache.py
+++ b/vc_vidyo/indico_vc_vidyo/api/cache.py
@@ -14,24 +14,21 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from suds.cache import Cache
+from zeep.cache import Base
 from indico.legacy.common.cache import GenericCache
 
 DEFAULT_CACHE_TTL = 24 * 3600
 
 
-class SudsCache(Cache):
+class ZeepCache(Base):
     _instance = None
 
     def __init__(self, duration=DEFAULT_CACHE_TTL):
-        self._cache = GenericCache("SudsCache")
+        self._cache = GenericCache("ZeepCache")
         self._duration = duration
 
-    def get(self, key):
-        self._cache.get(key)
+    def get(self, url):
+        self._cache.get(url)
 
-    def put(self, key, val):
-        self._cache.set(key, val, self._duration)
-
-    def purge(self, key):
-        self._cache.delete(key)
+    def add(self, url, content):
+        self._cache.set(url, content, self._duration)

--- a/vc_vidyo/indico_vc_vidyo/plugin.py
+++ b/vc_vidyo/indico_vc_vidyo/plugin.py
@@ -163,17 +163,24 @@ class VidyoPlugin(VCPluginMixin, IndicoPlugin):
         extension = next(extension_gen)
 
         while True:
+            room_mode = {
+                'isLocked': False,
+                'hasPIN': vc_room.data['room_pin'] != "",
+                'hasModeratorPIN': vc_room.data['moderation_pin'] != ""
+            }
+            if room_mode['hasPIN']:
+                room_mode['roomPIN'] = vc_room.data['room_pin']
+            if room_mode['hasModeratorPIN']:
+                room_mode['moderatorPIN'] = vc_room.data['moderation_pin']
+
             room_obj = client.create_room_object(
                 name=vc_room.name,
                 RoomType='Public',
                 ownerName=login,
                 extension=extension,
                 groupName=self.settings.get('room_group_name'),
-                description=vc_room.data['description'])
-
-            room_obj.RoomMode.isLocked = False
-            room_obj.RoomMode.hasPIN = vc_room.data['room_pin'] != ""
-            room_obj.RoomMode.hasModeratorPIN = vc_room.data['moderation_pin'] != ""
+                description=vc_room.data['description'],
+                RoomMode=room_mode)
 
             if room_obj.RoomMode.hasPIN:
                 room_obj.RoomMode.roomPIN = vc_room.data['room_pin']

--- a/vc_vidyo/setup.py
+++ b/vc_vidyo/setup.py
@@ -32,7 +32,7 @@ setup(
     platforms='any',
     install_requires=[
         'indico>=1.9.10',
-        'suds-jurko'
+        'zeep'
     ],
     classifiers=[
         'Environment :: Plugins',


### PR DESCRIPTION
It seems like suds' handling of Vidyo WSDL is broken.
[zeep](http://docs.python-zeep.org/en/master/) seems to be its rightful successor, kept up-to-date and designed in a more Pythonic way.