### PR TITLE
LiveSync: Ignore unrelated ACL changes

### DIFF
--- a/livesync/setup.py
+++ b/livesync/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='indico_livesync',
-    version='0.5',
+    version='0.5.1',
     url='https://github.com/indico/indico-plugins',
     license='https://www.gnu.org/licenses/gpl-3.0.txt',
     author='Indico Team',


### PR DESCRIPTION
AFAIK it only matters whether someone can access an object or not - but not whether they are a manager or just have read access.