### PR TITLE
WIP: implementation of placeholders in indico_payment_manual

### DIFF
--- a/payment_manual/indico_payment_manual/__init__.py
+++ b/payment_manual/indico_payment_manual/__init__.py
@@ -19,3 +19,13 @@ from __future__ import unicode_literals
 from indico.util.i18n import make_bound_gettext
 
 _ = make_bound_gettext('payment_manual')
+
+@signals.get_placeholders.connect_via('event-payment-form')
+def _get_payment_form_placeholders(sender, event, registration, **kwargs):
+    from indico_payment_manual.placeholders.payments import (IDPlaceholder, EventIDPlaceholder,
+                                                             FirstNamePlaceholder, LastNamePlaceholder)
+    yield IDPlaceholder
+    yield EventIDPlaceholder
+    yield FirstNamePlaceholder
+    yield LastNamePlaceholder
+

--- a/payment_manual/indico_payment_manual/__init__.py
+++ b/payment_manual/indico_payment_manual/__init__.py
@@ -16,6 +16,7 @@
 
 from __future__ import unicode_literals
 
+from indico.core import signals
 from indico.util.i18n import make_bound_gettext
 
 _ = make_bound_gettext('payment_manual')

--- a/payment_manual/indico_payment_manual/placeholders/payments.py
+++ b/payment_manual/indico_payment_manual/placeholders/payments.py
@@ -1,0 +1,56 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2017 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
+from indico.util.i18n import _
+from indico.util.placeholders import Placeholder
+
+
+class FirstNamePlaceholder(Placeholder):
+    name = 'first_name'
+    description = _("First name of the person")
+
+    @classmethod
+    def render(cls, event, registration):
+        return registration.first_name
+
+
+class LastNamePlaceholder(Placeholder):
+    name = 'last_name'
+    description = _("Last name of the person")
+
+    @classmethod
+    def render(cls, event, registration):
+        return registration.last_name
+
+
+class EventIDPlaceholder(Placeholder):
+    name = 'event_id'
+    description = _("The ID of the event")
+
+    @classmethod
+    def render(cls, event, registration):
+        return event.id
+
+
+class IDPlaceholder(Placeholder):
+    name = 'registration_id'
+    description = _("The ID of the registration")
+
+    @classmethod
+    def render(cls, event, registration):
+        return registration.friendly_id

--- a/payment_manual/indico_payment_manual/plugin.py
+++ b/payment_manual/indico_payment_manual/plugin.py
@@ -73,5 +73,5 @@ class ManualPaymentPlugin(PaymentPluginMixin, IndicoPlugin):
         event = data['event']
         event_settings = data['event_settings']
         registration = data['registration']
-        data['details'] = replace_placeholders('event-payment-form', event_settings.details,
+        data['details'] = replace_placeholders('event-payment-form', event_settings['details'],
                                                event=event, registration=registration)

--- a/payment_manual/indico_payment_manual/plugin.py
+++ b/payment_manual/indico_payment_manual/plugin.py
@@ -23,7 +23,7 @@ from indico.core.plugins import IndicoPlugin, IndicoPluginBlueprint, url_for_plu
 from indico.modules.events.payment import (PaymentPluginMixin, PaymentPluginSettingsFormBase,
                                            PaymentEventSettingsFormBase)
 from indico.web.forms.validators import UsedIf
-from indico.util.placeholders import render_placeholder_info, get_missing_placeholders
+from indico.util.placeholders import render_placeholder_info, replace_placeholders
 
 from indico_payment_manual import _
 
@@ -35,12 +35,19 @@ DETAILS_DESC = _('The details the user needs to make their payment. This usually
 class PluginSettingsForm(PaymentPluginSettingsFormBase):
     details = TextAreaField(_('Payment details'), [], description=DETAILS_DESC)
 
+    def __init__(self, *args, **kwargs):
+        super(PluginSettingsForm, self).__init__(*args, **kwargs)
+        self.details.description = DETAILS_DESC + '<br>' + render_placeholder_info('event-payment-form',
+                                                                                   event=None, registration=None)
+
 
 class EventSettingsForm(PaymentEventSettingsFormBase):
     details = TextAreaField(_('Payment details'), [UsedIf(lambda form, _: form.enabled.data), DataRequired()])
 
     def __init__(self, *args, **kwargs):
-        self.details.description = DETAILS_DESC + render_placeholder_info('event-payment-form', event=None, registration=None)
+        super(EventSettingsForm, self).__init__(*args, **kwargs)
+        self.details.description = DETAILS_DESC + '<br>' + render_placeholder_info('event-payment-form',
+                                                                                   event=None, registration=None)
 
 
 class ManualPaymentPlugin(PaymentPluginMixin, IndicoPlugin):
@@ -66,4 +73,5 @@ class ManualPaymentPlugin(PaymentPluginMixin, IndicoPlugin):
         event = data['event']
         event_settings = data['event_settings']
         registration = data['registration']
-        data['details'] = replace_placeholders('event-payment-form', event_settings.details, event=event, registration=registration)
+        data['details'] = replace_placeholders('event-payment-form', event_settings.details,
+                                               event=event, registration=registration)

--- a/payment_manual/indico_payment_manual/plugin.py
+++ b/payment_manual/indico_payment_manual/plugin.py
@@ -23,6 +23,7 @@ from indico.core.plugins import IndicoPlugin, IndicoPluginBlueprint, url_for_plu
 from indico.modules.events.payment import (PaymentPluginMixin, PaymentPluginSettingsFormBase,
                                            PaymentEventSettingsFormBase)
 from indico.web.forms.validators import UsedIf
+from indico.util.placeholders import render_placeholder_info, get_missing_placeholders
 
 from indico_payment_manual import _
 
@@ -36,8 +37,10 @@ class PluginSettingsForm(PaymentPluginSettingsFormBase):
 
 
 class EventSettingsForm(PaymentEventSettingsFormBase):
-    details = TextAreaField(_('Payment details'), [UsedIf(lambda form, _: form.enabled.data), DataRequired()],
-                            description=DETAILS_DESC)
+    details = TextAreaField(_('Payment details'), [UsedIf(lambda form, _: form.enabled.data), DataRequired()])
+
+    def __init__(self, *args, **kwargs):
+        self.details.description = DETAILS_DESC + render_placeholder_info('event-payment-form', event=None, registration=None)
 
 
 class ManualPaymentPlugin(PaymentPluginMixin, IndicoPlugin):
@@ -58,3 +61,9 @@ class ManualPaymentPlugin(PaymentPluginMixin, IndicoPlugin):
 
     def get_blueprints(self):
         return IndicoPluginBlueprint('payment_manual', __name__)
+
+    def adjust_payment_form_data(self, data):
+        event = data['event']
+        event_settings = data['event_settings']
+        registration = data['registration']
+        data['details'] = replace_placeholders('event-payment-form', event_settings.details, event=event, registration=registration)

--- a/payment_manual/indico_payment_manual/templates/event_payment_form.html
+++ b/payment_manual/indico_payment_manual/templates/event_payment_form.html
@@ -1,1 +1,1 @@
-{{ event_settings.details | markdown }}
+{{ details | markdown }}


### PR DESCRIPTION
This pull request is still WIP and aims at supporting the following placeholders in the payment description of the payment_manual plugin:

Placeholder | Replacement
------------|---------------
{event_id} | replaced by the ID of the vent
{registration_id} | replaced by the friendly ID of the registration
{first_name} | replaced by the first name of the registrant
{last_name} | repalced by the last name of the registrant

A unique ID per registration will probably be added later.