### PR TITLE
payment_manual: implementation of placeholders in description

### DIFF
--- a/payment_manual/indico_payment_manual/__init__.py
+++ b/payment_manual/indico_payment_manual/__init__.py
@@ -16,17 +16,7 @@
 
 from __future__ import unicode_literals
 
-from indico.core import signals
 from indico.util.i18n import make_bound_gettext
 
+
 _ = make_bound_gettext('payment_manual')
-
-
-@signals.get_placeholders.connect_via('event-payment-form')
-def _get_payment_form_placeholders(sender, regform, registration, **kwargs):
-    from indico.modules.events.registration.placeholders.registrations import FirstNamePlaceholder, LastNamePlaceholder
-    from indico_payment_manual.placeholders import RegistrationIDPlaceholder, EventIDPlaceholder
-    yield FirstNamePlaceholder
-    yield LastNamePlaceholder
-    yield RegistrationIDPlaceholder
-    yield EventIDPlaceholder

--- a/payment_manual/indico_payment_manual/placeholders.py
+++ b/payment_manual/indico_payment_manual/placeholders.py
@@ -16,17 +16,19 @@
 
 from __future__ import unicode_literals
 
-from indico.core import signals
-from indico.util.i18n import make_bound_gettext
+from indico_payment_manual import _
+from indico.util.placeholders import Placeholder
+from indico.modules.events.registration.placeholders.registrations import IDPlaceholder
 
-_ = make_bound_gettext('payment_manual')
+
+class RegistrationIDPlaceholder(IDPlaceholder):
+    name = 'registration_id'
 
 
-@signals.get_placeholders.connect_via('event-payment-form')
-def _get_payment_form_placeholders(sender, regform, registration, **kwargs):
-    from indico.modules.events.registration.placeholders.registrations import FirstNamePlaceholder, LastNamePlaceholder
-    from indico_payment_manual.placeholders import RegistrationIDPlaceholder, EventIDPlaceholder
-    yield FirstNamePlaceholder
-    yield LastNamePlaceholder
-    yield RegistrationIDPlaceholder
-    yield EventIDPlaceholder
+class EventIDPlaceholder(Placeholder):
+    name = 'event_id'
+    description = _("The ID of the event")
+
+    @classmethod
+    def render(cls, regform, registration):
+        return registration.registration_form.event_new.id

--- a/payment_manual/indico_payment_manual/plugin.py
+++ b/payment_manual/indico_payment_manual/plugin.py
@@ -38,7 +38,7 @@ class PluginSettingsForm(PaymentPluginSettingsFormBase):
 
     def __init__(self, *args, **kwargs):
         super(PluginSettingsForm, self).__init__(*args, **kwargs)
-        self.details.description = DETAILS_DESC + '\n' + render_placeholder_info('event-payment-form',
+        self.details.description = DETAILS_DESC + '\n' + render_placeholder_info('manual-payment-details',
                                                                                  regform=None, registration=None)
 
 
@@ -47,7 +47,7 @@ class EventSettingsForm(PaymentEventSettingsFormBase):
 
     def __init__(self, *args, **kwargs):
         super(EventSettingsForm, self).__init__(*args, **kwargs)
-        self.details.description = DETAILS_DESC + '\n' + render_placeholder_info('event-payment-form',
+        self.details.description = DETAILS_DESC + '\n' + render_placeholder_info('manual-payment-details',
                                                                                  regform=None, registration=None)
 
 
@@ -65,7 +65,7 @@ class ManualPaymentPlugin(PaymentPluginMixin, IndicoPlugin):
 
     def init(self):
         super(ManualPaymentPlugin, self).init()
-        self.connect(signals.get_placeholders, self._get_details_placeholders, sender='event-payment-form')
+        self.connect(signals.get_placeholders, self._get_details_placeholders, sender='manual-payment-details')
 
     def _get_details_placeholders(self, sender, regform, registration, **kwargs):
         from indico.modules.events.registration.placeholders.registrations import (FirstNamePlaceholder,
@@ -84,6 +84,6 @@ class ManualPaymentPlugin(PaymentPluginMixin, IndicoPlugin):
         return IndicoPluginBlueprint('payment_manual', __name__)
 
     def adjust_payment_form_data(self, data):
-        data['details'] = replace_placeholders('event-payment-form', data['event_settings']['details'],
+        data['details'] = replace_placeholders('manual-payment-details', data['event_settings']['details'],
                                                regform=data['registration'].registration_form,
                                                registration=data['registration'])

--- a/payment_manual/indico_payment_manual/plugin.py
+++ b/payment_manual/indico_payment_manual/plugin.py
@@ -23,6 +23,7 @@ from indico.core.plugins import IndicoPlugin, IndicoPluginBlueprint, url_for_plu
 from indico.modules.events.payment import (PaymentPluginMixin, PaymentPluginSettingsFormBase,
                                            PaymentEventSettingsFormBase)
 from indico.web.forms.validators import UsedIf
+from indico.util.placeholders import render_placeholder_info, replace_placeholders
 
 from indico_payment_manual import _
 
@@ -32,12 +33,21 @@ DETAILS_DESC = _('The details the user needs to make their payment. This usually
 
 
 class PluginSettingsForm(PaymentPluginSettingsFormBase):
-    details = TextAreaField(_('Payment details'), [], description=DETAILS_DESC)
+    details = TextAreaField(_('Payment details'), [])
+
+    def __init__(self, *args, **kwargs):
+        super(PluginSettingsForm, self).__init__(*args, **kwargs)
+        self.details.description = DETAILS_DESC + '\n' + render_placeholder_info('event-payment-form',
+                                                                                 regform=None, registration=None)
 
 
 class EventSettingsForm(PaymentEventSettingsFormBase):
-    details = TextAreaField(_('Payment details'), [UsedIf(lambda form, _: form.enabled.data), DataRequired()],
-                            description=DETAILS_DESC)
+    details = TextAreaField(_('Payment details'), [UsedIf(lambda form, _: form.enabled.data), DataRequired()])
+
+    def __init__(self, *args, **kwargs):
+        super(EventSettingsForm, self).__init__(*args, **kwargs)
+        self.details.description = DETAILS_DESC + '\n' + render_placeholder_info('event-payment-form',
+                                                                                 regform=None, registration=None)
 
 
 class ManualPaymentPlugin(PaymentPluginMixin, IndicoPlugin):
@@ -58,3 +68,8 @@ class ManualPaymentPlugin(PaymentPluginMixin, IndicoPlugin):
 
     def get_blueprints(self):
         return IndicoPluginBlueprint('payment_manual', __name__)
+
+    def adjust_payment_form_data(self, data):
+        data['details'] = replace_placeholders('event-payment-form', data['event_settings']['details'],
+                                               regform=data['registration'].registration_form,
+                                               registration=data['registration'])

--- a/payment_manual/indico_payment_manual/plugin.py
+++ b/payment_manual/indico_payment_manual/plugin.py
@@ -19,11 +19,12 @@ from __future__ import unicode_literals
 from wtforms.fields.simple import TextAreaField
 from wtforms.validators import DataRequired
 
+from indico.core import signals
 from indico.core.plugins import IndicoPlugin, IndicoPluginBlueprint, url_for_plugin
-from indico.modules.events.payment import (PaymentPluginMixin, PaymentPluginSettingsFormBase,
-                                           PaymentEventSettingsFormBase)
-from indico.web.forms.validators import UsedIf
+from indico.modules.events.payment import (PaymentEventSettingsFormBase, PaymentPluginMixin,
+                                           PaymentPluginSettingsFormBase)
 from indico.util.placeholders import render_placeholder_info, replace_placeholders
+from indico.web.forms.validators import UsedIf
 
 from indico_payment_manual import _
 
@@ -61,6 +62,19 @@ class ManualPaymentPlugin(PaymentPluginMixin, IndicoPlugin):
     settings_form = PluginSettingsForm
     event_settings_form = EventSettingsForm
     default_settings = {'method_name': 'Bank Transfer'}
+
+    def init(self):
+        super(ManualPaymentPlugin, self).init()
+        self.connect(signals.get_placeholders, self._get_details_placeholders, sender='event-payment-form')
+
+    def _get_details_placeholders(self, sender, regform, registration, **kwargs):
+        from indico.modules.events.registration.placeholders.registrations import (FirstNamePlaceholder,
+                                                                                   LastNamePlaceholder)
+        from indico_payment_manual.placeholders import RegistrationIDPlaceholder, EventIDPlaceholder
+        yield FirstNamePlaceholder
+        yield LastNamePlaceholder
+        yield RegistrationIDPlaceholder
+        yield EventIDPlaceholder
 
     @property
     def logo_url(self):

--- a/payment_manual/indico_payment_manual/templates/event_payment_form.html
+++ b/payment_manual/indico_payment_manual/templates/event_payment_form.html
@@ -1,1 +1,1 @@
-{{ event_settings.details | markdown }}
+{{ details | markdown }}

--- a/payment_manual/setup.py
+++ b/payment_manual/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='indico_payment_manual',
-    version='0.1',
+    version='0.2.0',
     url='https://github.com/indico/indico-plugins',
     license='https://www.gnu.org/licenses/gpl-3.0.txt',
     author='Indico Team',


### PR DESCRIPTION
This pull request is still WIP and aims at supporting the following placeholders in the payment description of the payment_manual plugin:

Placeholder | Replacement
------------|---------------
{event_id} | replaced by the ID of the vent
{registration_id} | replaced by the friendly ID of the registration
{first_name} | replaced by the first name of the registrant
{last_name} | repalced by the last name of the registrant

A unique ID per registration will probably be added later (not part of this PR).