### PR TITLE
Add Email Placeholder

### DIFF
--- a/payment_manual/indico_payment_manual/placeholders.py
+++ b/payment_manual/indico_payment_manual/placeholders.py
@@ -56,6 +56,12 @@ class LastNamePlaceholder(EscapablePlaceholder):
     field = 'last_name'
 
 
+class EmailPlaceholder(EscapablePlaceholder):
+    name = 'email'
+    basic_description = _("Email address of the registrant")
+    field = 'email'
+
+
 class RegistrationIDPlaceholder(IDPlaceholder):
     name = 'registration_id'
 

--- a/payment_manual/indico_payment_manual/plugin.py
+++ b/payment_manual/indico_payment_manual/plugin.py
@@ -73,11 +73,12 @@ class ManualPaymentPlugin(PaymentPluginMixin, IndicoPlugin):
         self.connect(signals.get_placeholders, self._get_details_placeholders, sender='manual-payment-details')
 
     def _get_details_placeholders(self, sender, regform, registration, **kwargs):
-        from indico_payment_manual.placeholders import (FirstNamePlaceholder, LastNamePlaceholder,
+        from indico_payment_manual.placeholders import (FirstNamePlaceholder, LastNamePlaceholder, EmailPlaceholder,
                                                         RegistrationIDPlaceholder, EventIDPlaceholder, PricePlaceholder,
                                                         CurrencyPlaceholder)
         yield FirstNamePlaceholder
         yield LastNamePlaceholder
+        yield EmailPlaceholder
         yield RegistrationIDPlaceholder
         yield EventIDPlaceholder
         yield PricePlaceholder

--- a/payment_manual/setup.py
+++ b/payment_manual/setup.py
@@ -21,7 +21,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='indico-plugin-payment-manual',
-    version='1.0',
+    version='1.0.1',
     description='Payment plugin for Indico that can be used for custom payment information/links',
     url='https://github.com/indico/indico-plugins',
     license='https://www.gnu.org/licenses/gpl-3.0.txt',


### PR DESCRIPTION
Suggested change to 'indico-plugins' plugin named 'payment_manual' that adds Email as a field placeholder that can be added into the 'Payment details' text box when configuring the manual payment for an event