### PR TITLE
Payment Manual: Implemented pending transactions

### DIFF
--- a/payment_manual/indico_payment_manual/blueprint.py
+++ b/payment_manual/indico_payment_manual/blueprint.py
@@ -1,0 +1,28 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
+from indico.core.plugins import IndicoPluginBlueprint
+
+from indico_payment_manual.controllers import RHManualConfirm, RHManualReceived
+
+
+blueprint = IndicoPluginBlueprint('payment_manual', __name__,
+                                  url_prefix='/event/<confId>/registrations/<int:reg_form_id>/payment/manual')
+
+blueprint.add_url_rule('/confirm', 'confirm', RHManualConfirm, methods=('GET',))
+blueprint.add_url_rule('/received', 'received', RHManualReceived, methods=('GET',))

--- a/payment_manual/indico_payment_manual/controllers.py
+++ b/payment_manual/indico_payment_manual/controllers.py
@@ -1,0 +1,74 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
+from flask import flash, redirect, request, session
+from werkzeug.exceptions import BadRequest
+
+from indico.modules.events.payment.models.transactions import TransactionAction
+from indico.modules.events.payment.util import register_transaction
+from indico.modules.events.registration.models.registrations import Registration
+from indico.modules.events.registration.controllers.management import RHManageRegFormsBase
+from indico.web.flask.util import url_for
+from indico.web.flask.templating import get_template_module
+from indico.web.rh import RH
+from indico.web.util import jsonify_data
+
+from indico_payment_paypal import _
+
+
+class RHManualConfirm(RH):
+    """Process the manual confirmation by the user"""
+
+    def _process_args(self):
+        self.token = request.args['token']
+        self.registration = Registration.find_first(uuid=self.token)
+        if not self.registration:
+            raise BadRequest
+
+    def _process(self):
+        register_transaction(registration=self.registration,
+                             amount=self.registration.price,
+                             currency=self.registration.currency,
+                             action=TransactionAction.pending,
+                             provider='manual',
+                             data={})
+
+        flash(_('Please wait two to three business days until we have received your payment.'), 'info')
+        return redirect(url_for('event_registration.display_regform', self.registration.locator.registrant))
+
+
+class RHManualReceived(RHManageRegFormsBase):
+    """Modify the payment status of a registration"""
+
+    def _process_args(self):
+        self.token = request.args['token']
+        self.registration = Registration.find_first(uuid=self.token)
+        if not self.registration:
+            raise BadRequest
+        self.event = self.registration.event
+
+    def _process(self):
+        register_transaction(registration=self.registration,
+                             amount=self.registration.transaction.amount,
+                             currency=self.registration.transaction.currency,
+                             action=TransactionAction.complete,
+                             provider='manual',
+                             data={'changed_by_name': session.user.full_name,
+                                   'changed_by_id': session.user.id})
+        return redirect(url_for('event_registration.registration_details', self.registration))
+

--- a/payment_manual/indico_payment_manual/templates/event_payment_form.html
+++ b/payment_manual/indico_payment_manual/templates/event_payment_form.html
@@ -1,1 +1,23 @@
 {{ details | markdown }}
+
+{% if trigger_pending %}
+    <div class="checkbox-with-text">
+        <input type="checkbox" id="payment-manual-agree">
+        <div>
+            {% trans %}I understand that the registration will be completed only after the bank transfer is received. A bank trasfer usually takes two to three business days. Until then the status of your registration will remain „awaiting payment“. You will receive an email confirming your payment once the bank transfer is completed.{% endtrans %}
+        </div>
+    </div>
+    <p class="text-right">
+        <button type="button" id="payment-manual-confirm" class="action-button" data-url="{{ confirm_url }}">{% trans %}Confirm{% endtrans %}</button>
+    </p>
+    <script type="text/javascript">
+        $("#payment-manual-confirm").on("click", function(e) {
+            if ($("#payment-manual-agree").is(":checked")) {
+                location.href = $(this).data("url");
+            }
+            else {
+                $("#payment-manual-agree").parent().effect('highlight', 800);
+            }
+        });
+    </script>
+{% endif %}

--- a/payment_manual/indico_payment_manual/templates/transaction_details.html
+++ b/payment_manual/indico_payment_manual/templates/transaction_details.html
@@ -1,0 +1,39 @@
+{% extends 'events/payment/transaction_details.html' %}
+{% from 'message_box.html' import message_box %}
+
+{% block details %}
+    {% if transaction.status.name == 'pending' %}
+        <dt>{% trans %}Status{% endtrans %}</dt>
+        <dd>{% trans %}Awaiting bank transfer{% endtrans %}</dd>
+        <dt>&nbsp;</dt>
+        <dd>
+            <a class="i-button"
+               href="{{ url_for('plugin_payment_manual.received', transaction.registration.locator.uuid) }}">
+                {% trans %}Mark as received{% endtrans %}
+            </a>
+        </dd>
+    {% else %}
+        <dt>{% trans %}Status{% endtrans %}</dt>
+        <dd>{% trans %}Bank transfer received{% endtrans %}</dd>
+        <dt>{% trans %}Marked as paid by{% endtrans %}</dt>
+        <dd>{{ transaction.data.changed_by_name }}</dd>
+    {% endif %}
+{% endblock %}
+
+{% block warning_box %}
+    {% if transaction.amount != transaction.registration.price %}
+        {% call message_box('warning') %}
+            <p>
+                {%- trans %}The paid amount does not match the required amount. Please contact the registrant to solve the issue.{% endtrans -%}
+            </p>
+            <p>
+                {%- trans %}Paid: {% endtrans -%}
+                {{- format_currency(transaction.amount, transaction.currency, locale=session.lang) -}}
+            </p>
+            <p>
+                {%- trans %}Required: {% endtrans -%}
+                {{- transaction.registration.render_price() -}}
+            </p>
+        {% endcall %}
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Currently, when the `payment_manual` plugin is used for bank transfers, the registration will be marked as unpaid for quite a long time. This is irritating for the user, who probably has already initiated the bank transfer.

This pull request adds an optional feature to `payment_manual`, which adds a pending transaction to the registration. The feature can be configured on a per-event basis in the management area:

![plugin-settings](https://user-images.githubusercontent.com/1586788/40174720-3132eb1e-59d6-11e8-8e18-3cdfd74e1f32.png)

If enabled, users have to explicitly confirm the checkout by ticking a checkbox:

![plugin-checkout](https://user-images.githubusercontent.com/1586788/40174925-d2297326-59d6-11e8-800c-166c601ce729.png)

After the explicit checkout, a pending transaction is created in the database. Together with indico/indico#3361 this prevents that users can change anything about their registration, neither can they check out a second time. In the management area, a manager can approve the receival of the transfer:

![plugin-transaction](https://user-images.githubusercontent.com/1586788/40174792-59e3aca6-59d6-11e8-9c41-665c18824f56.png)
