### PR TITLE
Storage/S3: Use high-level API supporting chunks

### DIFF
--- a/storage_s3/setup.py
+++ b/storage_s3/setup.py
@@ -12,7 +12,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='indico-plugin-storage-s3',
-    version='2.3.1',
+    version='2.3.2',
     description='S3 storage backend for Indico',
     url='https://github.com/indico/indico-plugins',
     license='MIT',


### PR DESCRIPTION
Otherwise it's impossible to store files larger than 5GB. We always include the header with the checksum now, because there is no harm in doing so and otherwise we'd have to first check how large the file we're storing is...

closes #87