### PR TITLE
Include Zoom join URL(s) in ICAL files

### DIFF
--- a/vc_zoom/README.md
+++ b/vc_zoom/README.md
@@ -27,6 +27,7 @@
 - Do not allow passcodes that are too long for zoom
 - Remove the "Assistant Zoom ID" logic due to problems with Zoom's API rate limits (all meetings created were counted against the assistant's rate limit instead of the host's); this means the host can no longer be changed, but Indico instead provides an option to event managers to make themselves a co-host.
 - Fix an error when changing the linked object of a recurring Zoom room in Indico
+- Include Zoom join links in the event's ical export (note: only Zoom meetings with a public passcode are displayed unless you have at least Indico v2.3.3)
 
 **Breaking change:** The email domains are now stored as a list of strings instead of a comma-separated list. You need to update them in the plugin settings.
 


### PR DESCRIPTION
We can most likely use the same APIs as in #71 for this.

Important: This must not expose private join links (with the passcode included) to people who would otherwise not have access. We may need to include the user in the `metadata_postprocess` signal since in case of a call through the HTTP API we do not have a `session.user`.