### PR TITLE
Citadel: Rename model/table

### DIFF
--- a/citadel/indico_citadel/backend.py
+++ b/citadel/indico_citadel/backend.py
@@ -111,6 +111,7 @@ class LiveSyncCitadelUploader(Uploader):
         new_citadel_id = response_data['metadata']['control_number']
         try:
             CitadelIdMap.create(object_type, object_id, new_citadel_id)
+            db.session.commit()
         except IntegrityError:
             # if we already have a mapping entry, delete the newly created record and
             # update the existing one in case something changed in the meantime

--- a/citadel/indico_citadel/cli.py
+++ b/citadel/indico_citadel/cli.py
@@ -11,7 +11,7 @@ from indico.cli.core import cli_group
 from indico.core.db import db
 from indico.util.console import cformat
 
-from indico_citadel.models.search_id_map import CitadelSearchAppIdMap
+from indico_citadel.models.id_map import CitadelIdMap
 from indico_livesync.models.agents import LiveSyncAgent
 
 
@@ -32,7 +32,7 @@ def upload(batch, force, max_size):
     if agent is None:
         print('No citadel livesync agent found')
         return
-    if not CitadelSearchAppIdMap.query.has_rows():
+    if not CitadelIdMap.query.has_rows():
         print('It looks like you did not export any data to Citadel yet.')
         print(cformat('To do so, run %{yellow!}indico livesync initial-export {}%{reset}').format(agent.id))
         return

--- a/citadel/indico_citadel/migrations/20210330_1742_0cf18be7ade1_add_mapping_table.py
+++ b/citadel/indico_citadel/migrations/20210330_1742_0cf18be7ade1_add_mapping_table.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql.ddl import CreateSchema, DropSchema
 
-from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
+from indico.core.db.sqlalchemy import PyIntEnum
 
 
 # revision identifiers, used by Alembic.
@@ -35,7 +35,6 @@ def upgrade():
         'id_map',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('citadel_id', sa.Integer(), nullable=False, index=True, unique=True),
-        sa.Column('timestamp', UTCDateTime, nullable=False),
         sa.Column('entry_type', PyIntEnum(_EntryType), nullable=False),
         sa.Column('event_id', sa.Integer(), nullable=True, index=True, unique=True),
         sa.Column('contrib_id', sa.Integer(), nullable=True, index=True, unique=True),

--- a/citadel/indico_citadel/migrations/20210330_1742_0cf18be7ade1_add_mapping_table.py
+++ b/citadel/indico_citadel/migrations/20210330_1742_0cf18be7ade1_add_mapping_table.py
@@ -32,9 +32,9 @@ class _EntryType(int, Enum):
 def upgrade():
     op.execute(CreateSchema('plugin_citadel'))
     op.create_table(
-        'es_id_map',
+        'id_map',
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('search_id', sa.Integer(), nullable=False, index=True, unique=True),
+        sa.Column('citadel_id', sa.Integer(), nullable=False, index=True, unique=True),
         sa.Column('timestamp', UTCDateTime, nullable=False),
         sa.Column('entry_type', PyIntEnum(_EntryType), nullable=False),
         sa.Column('event_id', sa.Integer(), nullable=True, index=True, unique=True),
@@ -60,5 +60,5 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_table('es_id_map', schema='plugin_citadel')
+    op.drop_table('id_map', schema='plugin_citadel')
     op.execute(DropSchema('plugin_citadel'))

--- a/citadel/indico_citadel/models/id_map.py
+++ b/citadel/indico_citadel/models/id_map.py
@@ -58,8 +58,8 @@ def _make_checks():
         yield db.CheckConstraint(condition, f'valid_{link_type.name}_entry')
 
 
-class CitadelSearchAppIdMap(db.Model):
-    __tablename__ = 'es_id_map'
+class CitadelIdMap(db.Model):
+    __tablename__ = 'id_map'
     __table_args__ = tuple(_make_checks()) + ({'schema': 'plugin_citadel'},)
 
     #: Entry ID
@@ -69,8 +69,8 @@ class CitadelSearchAppIdMap(db.Model):
         primary_key=True
     )
 
-    #: ID of the document in the backend this entry belongs to
-    search_id = db.Column(
+    #: ID of the document on Citadel
+    citadel_id = db.Column(
         db.Integer,
         nullable=False,
         index=True,
@@ -204,29 +204,29 @@ class CitadelSearchAppIdMap(db.Model):
     )
 
     @classmethod
-    def get_search_id(cls, obj_type, obj_id):
-        """Get the search_id for a given object type and id.
+    def get_citadel_id(cls, obj_type, obj_id):
+        """Get the citadel_id for a given object type and id.
 
         :param obj_type: The EntryType of the object
         :param obj_id: The id of the object
         """
-        query = db.session.query(cls.search_id).filter_by(entry_type=obj_type)
+        query = db.session.query(cls.citadel_id).filter_by(entry_type=obj_type)
         attr = _column_for_types.get(obj_type)
         if not attr:
             raise Exception(f'Unsupported object type {obj_type}')
         return query.filter(getattr(cls, attr) == obj_id).scalar()
 
     @classmethod
-    def create(cls, obj_type, obj_id, search_id):
+    def create(cls, obj_type, obj_id, citadel_id):
         """Create a new mapping.
 
         :param obj_type: The EntryType of the object
         :param obj_id: The id of the object
-        :param search_id: The citadel entry ID
+        :param citadel_id: The citadel entry ID
         """
         attr = _column_for_types.get(obj_type)
         if not attr:
             raise Exception(f'Unsupported object type {obj_type}')
-        entry = cls(search_id=search_id, entry_type=obj_type, **{attr: obj_id})
+        entry = cls(citadel_id=citadel_id, entry_type=obj_type, **{attr: obj_id})
         db.session.add(entry)
         db.session.commit()

--- a/citadel/indico_citadel/models/id_map.py
+++ b/citadel/indico_citadel/models/id_map.py
@@ -61,28 +61,20 @@ class CitadelIdMap(db.Model):
     __tablename__ = 'id_map'
     __table_args__ = tuple(_make_checks()) + ({'schema': 'plugin_citadel'},)
 
-    #: Entry ID
     id = db.Column(
         db.Integer,
-        autoincrement=True,
         primary_key=True
     )
-
-    #: ID of the document on Citadel
     citadel_id = db.Column(
         db.Integer,
         nullable=False,
         index=True,
         unique=True
     )
-
-    #: The type of the search entry object
     entry_type = db.Column(
         PyIntEnum(EntryType),
         nullable=False
     )
-
-    #: ID of the search entry event
     event_id = db.Column(
         db.Integer,
         db.ForeignKey('events.events.id'),
@@ -90,8 +82,6 @@ class CitadelIdMap(db.Model):
         nullable=True,
         unique=True
     )
-
-    #: ID of the search entry contribution
     contrib_id = db.Column(
         db.Integer,
         db.ForeignKey('events.contributions.id'),
@@ -99,8 +89,6 @@ class CitadelIdMap(db.Model):
         nullable=True,
         unique=True
     )
-
-    #: ID of the search entry subcontribution
     subcontrib_id = db.Column(
         db.Integer,
         db.ForeignKey('events.subcontributions.id'),
@@ -108,8 +96,6 @@ class CitadelIdMap(db.Model):
         nullable=True,
         unique=True
     )
-
-    #: ID of the search entry attachment
     attachment_id = db.Column(
         db.Integer,
         db.ForeignKey('attachments.attachments.id'),
@@ -117,8 +103,6 @@ class CitadelIdMap(db.Model):
         nullable=True,
         unique=True
     )
-
-    #: ID of the search entry note
     note_id = db.Column(
         db.Integer,
         db.ForeignKey('events.notes.id'),
@@ -126,8 +110,6 @@ class CitadelIdMap(db.Model):
         nullable=True,
         unique=True
     )
-
-    #: ID of the search entry file
     attachment_file_id = db.Column(
         db.Integer,
         db.ForeignKey('attachments.files.id'),
@@ -145,7 +127,6 @@ class CitadelIdMap(db.Model):
             lazy=True
         )
     )
-
     contribution = db.relationship(
         'Contribution',
         lazy=True,
@@ -155,7 +136,6 @@ class CitadelIdMap(db.Model):
             lazy=True
         )
     )
-
     subcontribution = db.relationship(
         'SubContribution',
         lazy=True,
@@ -165,7 +145,6 @@ class CitadelIdMap(db.Model):
             lazy=True
         )
     )
-
     attachment = db.relationship(
         'Attachment',
         lazy=True,
@@ -175,7 +154,6 @@ class CitadelIdMap(db.Model):
             lazy=True
         )
     )
-
     note = db.relationship(
         'EventNote',
         lazy=True,
@@ -185,7 +163,6 @@ class CitadelIdMap(db.Model):
             lazy=True
         )
     )
-
     attachment_file = db.relationship(
         'AttachmentFile',
         lazy=True,

--- a/citadel/indico_citadel/models/id_map.py
+++ b/citadel/indico_citadel/models/id_map.py
@@ -6,13 +6,12 @@
 # see the LICENSE file for more details.
 
 from indico.core.db import db
-from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
+from indico.core.db.sqlalchemy import PyIntEnum
 from indico.modules.attachments import Attachment
 from indico.modules.events import Event
 from indico.modules.events.contributions import Contribution
 from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.modules.events.notes.models.notes import EventNote
-from indico.util.date_time import now_utc
 from indico.util.enum import IndicoEnum
 
 
@@ -75,12 +74,6 @@ class CitadelIdMap(db.Model):
         nullable=False,
         index=True,
         unique=True
-    )
-
-    timestamp = db.Column(
-        UTCDateTime,
-        nullable=False,
-        default=now_utc
     )
 
     #: The type of the search entry object

--- a/citadel/indico_citadel/models/id_map.py
+++ b/citadel/indico_citadel/models/id_map.py
@@ -199,4 +199,3 @@ class CitadelIdMap(db.Model):
             raise Exception(f'Unsupported object type {obj_type}')
         entry = cls(citadel_id=citadel_id, entry_type=obj_type, **{attr: obj_id})
         db.session.add(entry)
-        db.session.commit()


### PR DESCRIPTION
`search_id` was always a bit strange, so I'm using `citadel_id` now.
Also, the table name is closer to the model name now.