### PR TITLE
Integrate placeholders with Indico

### DIFF
--- a/citadel/indico_citadel/search.py
+++ b/citadel/indico_citadel/search.py
@@ -11,7 +11,7 @@ import requests
 from requests.exceptions import RequestException
 from werkzeug.urls import url_join
 
-from indico.modules.search.base import IndicoSearchProvider
+from indico.modules.search.base import IndicoSearchProvider, SearchPlaceholder
 
 from indico_citadel import _
 from indico_citadel.util import format_filters, format_query
@@ -77,7 +77,7 @@ class CitadelProvider(IndicoSearchProvider):
         return total, min(math.ceil(total / self.RESULTS_PER_PAGE), 1000), objects, aggregations
 
     def get_placeholders(self):
-        return [{'key': key, 'label': label} for key, (_, label) in placeholders.items()]
+        return [SearchPlaceholder(key, label) for key, (_, label) in placeholders.items()]
 
 
 placeholders = {


### PR DESCRIPTION
While debating on whether we should keep these placeholders (and i18n) supported by Indico or provided by the plugin, I've decided to go for the latter as different search providers may support distinct placeholders.