### PR TITLE
Citadel: Integrate filters with Indico and update placeholders

### DIFF
--- a/citadel/indico_citadel/search.py
+++ b/citadel/indico_citadel/search.py
@@ -64,10 +64,10 @@ placeholders = {
     'person': ('_data.persons.name', _("A speaker, author or event chair's name")),
     'affiliation': ('_data.persons.affiliation', _("A speaker, author or event chair's affiliation")),
     'type': ('_data.type', _('An entry type (such as: conference, meeting, link, file)')),
-    'venue': ('_data.location.venue_name', _("The entry's venue name")),
-    'room': ('_data.location.room_name', _("The entry's room name")),
-    'address': ('_data.location.address', _("The entry's address")),
-    'file': ('_data.filename', _("An attachment's file name")),
+    'venue': ('_data.location.venue_name', _("Name of the venue")),
+    'room': ('_data.location.room_name', _("Name of the room")),
+    'address': ('_data.location.address', _("Address of the venue")),
+    'file': ('_data.filename', _("Name of the attached file")),
     'keyword': ('_data.keywords', _('A keyword associated with an event'))
 }
 
@@ -80,6 +80,6 @@ filters = {
     'person': _('Person'),
     'type_format': _('Type'),
     'venue': _('Location'),
-    'start_range': _('Start Date'),
+    'start_range': _('Date'),
     'category': _('Category')
 }

--- a/citadel/indico_citadel/search.py
+++ b/citadel/indico_citadel/search.py
@@ -9,7 +9,7 @@ import requests
 from requests.exceptions import RequestException
 from werkzeug.urls import url_join
 
-from indico.modules.search.base import IndicoSearchProvider, SearchPlaceholder
+from indico.modules.search.base import IndicoSearchProvider, SearchFilter
 
 from indico_citadel import _
 from indico_citadel.result_schemas import CitadelResultSchema
@@ -53,7 +53,10 @@ class CitadelProvider(IndicoSearchProvider):
         return CitadelResultSchema(context={'results_per_page': self.RESULTS_PER_PAGE}).load(data)
 
     def get_placeholders(self):
-        return [SearchPlaceholder(key, label) for key, (_, label) in placeholders.items()]
+        return [SearchFilter(key, label) for key, (_, label) in placeholders.items()]
+
+    def get_filters(self):
+        return [SearchFilter(key, label) for key, label in filters.items()]
 
 
 placeholders = {
@@ -61,7 +64,10 @@ placeholders = {
     'person': ('_data.persons.name', _("A speaker, author or event chair's name")),
     'affiliation': ('_data.persons.affiliation', _("A speaker, author or event chair's affiliation")),
     'type': ('_data.type', _('An entry type (such as: conference, meeting, link, file)')),
-    'venue': ('_data.location.venue_name', _("The event's venue name")),  # TODO: multiple locations
+    'venue': ('_data.location.venue_name', _("The entry's venue name")),
+    'room': ('_data.location.room_name', _("The entry's room name")),
+    'address': ('_data.location.address', _("The entry's address")),
+    'file': ('_data.filename', _("An attachment's file name")),
     'keyword': ('_data.keywords', _('A keyword associated with an event'))
 }
 
@@ -69,11 +75,11 @@ range_filters = {
     'start_range': 'start_dt'
 }
 
-# TODO: potentially move this to Indico (and provide i18n)
 filters = {
-    'affiliation': 'Affiliation',
-    'person': 'Person',
-    'type_format': 'Type',
-    'venue': 'Location',
-    'start_range': 'Start Date',
+    'affiliation': _('Affiliation'),
+    'person': _('Person'),
+    'type_format': _('Type'),
+    'venue': _('Location'),
+    'start_range': _('Start Date'),
+    'category': _('Category')
 }

--- a/citadel/indico_citadel/util.py
+++ b/citadel/indico_citadel/util.py
@@ -81,7 +81,7 @@ def format_filters(params, filters, range_filters):
 
 def escape(query):
     """Prepend all special ElasticSearch characters with a backslash."""
-    patt = r'([+\-=><!(){}[\]\^"~*?:\\\/]|&&|\|\|)'
+    patt = r'([+\-=><!(){}[\]\^"~?:\\\/]|&&|\|\|)'
     return re.sub(patt, r'\\\1', query)
 
 

--- a/citadel/indico_citadel/util_test.py
+++ b/citadel/indico_citadel/util_test.py
@@ -19,9 +19,10 @@ from indico_citadel.util import format_query, remove_none_entries
     ('title:something hey', '+title:something +(hey)'),
     ('hey title:something hey person:john', '+title:something +person:john +(hey hey)'),
     ('<*\\^()', '+(\\<*\\\\\\^\\(\\))'),
+    ('file:*.pdf', '+file:*.pdf')
 ])
 def test_query_placeholders(query, expected):
-    placeholders = {'title': 'title', 'person': 'person'}
+    placeholders = {'title': 'title', 'person': 'person', 'file': 'file'}
     assert format_query(query, placeholders) == expected
 
 

--- a/citadel/indico_citadel/util_test.py
+++ b/citadel/indico_citadel/util_test.py
@@ -18,7 +18,7 @@ from indico_citadel.util import format_query, remove_none_entries
     ('hey title:something', '+title:something +(hey)'),
     ('title:something hey', '+title:something +(hey)'),
     ('hey title:something hey person:john', '+title:something +person:john +(hey hey)'),
-    ('<*\\^()', '+(\\<\\*\\\\\\^\\(\\))'),
+    ('<*\\^()', '+(\\<*\\\\\\^\\(\\))'),
 ])
 def test_query_placeholders(query, expected):
     placeholders = {'title': 'title', 'person': 'person'}


### PR DESCRIPTION
Even though we don't need to pass the filters into Indico, as most of them come directly within the result aggregations, having them available is useful for providing i18n or getting their name from the query string.

Having a pre-defined list of them available through Indico or the search plugin is discussible. Even though I think it makes more sense the latter, as this PR, since they should change between implementations.