### PR TITLE
Use all worker threads all the time

### DIFF
--- a/citadel/indico_citadel/backend.py
+++ b/citadel/indico_citadel/backend.py
@@ -105,6 +105,7 @@ class LiveSyncCitadelUploader(Uploader):
         raise ValueError(f'unknown object ref: {obj}')
 
     def _citadel_create(self, session, object_type, object_id, data):
+        self.logger.debug('Creating %s %d on citadel', object_type.name, object_id)
         try:
             resp = session.post(self.endpoint_url, json=data)
             resp.raise_for_status()
@@ -130,6 +131,7 @@ class LiveSyncCitadelUploader(Uploader):
         resp.close()
 
     def _citadel_update(self, session, citadel_id, data):
+        self.logger.debug('Updating record %d on citadel', citadel_id)
         try:
             resp = session.put(url_join(self.search_app, f'api/record/{citadel_id}'), json=data)
             resp.raise_for_status()
@@ -141,6 +143,7 @@ class LiveSyncCitadelUploader(Uploader):
             raise Exception(f'Could not update record {citadel_id} on citadel: {exc}; {data}')
 
     def _citadel_delete(self, session, citadel_id, *, delete_mapping):
+        self.logger.debug('Deleting record %d from citadel', citadel_id)
         try:
             resp = session.delete(url_join(self.search_app, f'api/record/{citadel_id}'))
             resp.raise_for_status()

--- a/citadel/indico_citadel/backend.py
+++ b/citadel/indico_citadel/backend.py
@@ -241,7 +241,7 @@ class LiveSyncCitadelUploader(Uploader):
         session.headers = self.headers
         uploader = parallelize(self.upload_file, entries=files, batch_size=self.PARALLELISM_FILES)
         results, aborted = uploader(session)
-        return sum(1 for success in results if not success), aborted
+        return len(results), sum(1 for success in results if not success), aborted
 
 
 class LiveSyncCitadelBackend(LiveSyncBackendBase):
@@ -328,7 +328,7 @@ class LiveSyncCitadelBackend(LiveSyncBackendBase):
                                            print_total_time=True)
         else:
             self.plugin.logger.info(f'{total} files need to be uploaded')
-        errors, aborted = uploader.upload_files(attachments)
+        total, errors, aborted = uploader.upload_files(attachments)
         return total, errors, aborted
 
     def check_reset_status(self):

--- a/citadel/indico_citadel/backend.py
+++ b/citadel/indico_citadel/backend.py
@@ -189,10 +189,12 @@ class LiveSyncCitadelUploader(Uploader):
             entry.attachment_file_id = entry.attachment.file.id
             db.session.merge(entry)
             db.session.commit()
+            resp.close()
             return True
         else:
             self.logger.error('Failed uploading attachment %d: [%d] %s',
                               entry.attachment.id, resp.status_code, resp.text)
+            resp.close()
             return False
 
     def run_initial(self, events, total):

--- a/citadel/indico_citadel/cli.py
+++ b/citadel/indico_citadel/cli.py
@@ -42,11 +42,13 @@ def upload(batch, force, max_size):
         print('Citadel is not properly configured.')
         return
 
-    total, errors = backend.run_export_files(batch, force, max_size=max_size)
-    if not errors:
+    total, errors, aborted = backend.run_export_files(batch, force, max_size=max_size)
+    if not errors and not aborted:
         print(f'{total} files uploaded')
         backend.set_initial_file_upload_state(True)
         db.session.commit()
     else:
+        if aborted:
+            print('Upload aborted')
         print(f'{total} files uploaded, but {errors} failed')
         print('Please re-run this script; queue runs will remain disabled for now')

--- a/citadel/indico_citadel/cli.py
+++ b/citadel/indico_citadel/cli.py
@@ -50,5 +50,5 @@ def upload(batch, force, max_size):
     else:
         if aborted:
             print('Upload aborted')
-        print(f'{total} files uploaded, but {errors} failed')
+        print(f'{total} files processed, {errors} failed')
         print('Please re-run this script; queue runs will remain disabled for now')


### PR DESCRIPTION
The previous thread pool implementation launched n threads but then waited for all of them to finish before launching the next n. This one processes the data constantly instead of waiting for a full batch to finish.