### PR TITLE
Refactor the search query parser

### DIFF
--- a/citadel/indico_citadel/util_test.py
+++ b/citadel/indico_citadel/util_test.py
@@ -12,16 +12,18 @@ from indico_citadel.util import format_query, remove_none_entries
 
 @pytest.mark.parametrize(('query', 'expected'), [
     ('title:"my event" ola person:john ola some:yes ola',
-     '+title:"my event" +person:john +(ola ola some\\:yes ola)'),
-    ('title:"my title:something"', '+title:"my title:something"'),
-    ('hello', '+(hello)'),
-    ('hey title:something', '+title:something +(hey)'),
-    ('title:something hey', '+title:something +(hey)'),
-    ('hey title:something hey person:john', '+title:something +person:john +(hey hey)'),
-    ('<*\\^()', '+(\\<*\\\\\\^\\(\\))'),
+     '+title:"my event" ola +person:john ola some\\:yes ola'),
+    ('title:"my title:something"', '+title:"my title\\:something"'),
+    ('hello   ', 'hello   '),
+    ('hey title:something', 'hey +title:something'),
+    ('title:something hey', '+title:something hey'),
+    ('hey title:something hey person:john', 'hey +title:something hey +person:john'),
+    ('<*\\^()', '\\<*\\\\\\^\\(\\)'),
     ('file:*.pdf', '+file:*.pdf'),
-    ('title:"meeting" "jane doe"', '+title:"meeting" +("jane doe")'),
-    ('"section meeting" OR "group meeting"', '+("section meeting" OR "group meeting")')
+    ('title:"meeting" "jane doe"', '+title:"meeting" "jane doe"'),
+    ('"section meeting" OR "group meeting"', '"section meeting" OR "group meeting"'),
+    ('title:meeting AND "indico"', '+title:meeting AND "indico"'),
+    ('title:valid stringtitle:valid foo:bar', '+title:valid stringtitle\\:valid foo\\:bar')
 ])
 def test_query_placeholders(query, expected):
     placeholders = {'title': 'title', 'person': 'person', 'file': 'file'}


### PR DESCRIPTION
Escape everything except for valid placeholders. Also ensures the original keyword positioning isn't changed.

The old logic splitter placeholders and keywords:
Input: `hey title:john hey`
Ouput: `+title:john +(hey hey)`

Input: `title:john AND "developers meeting"`
Output: `+title:john +(AND "developers meeting")` -- Error

The new logic ensures the content and positioning is preserved only doing light parsing for escaping and whitelisting placeholders:
Input: `hey title:john hey invalid_placeholder:foo`
Output: `hey +title:john hey invalid_placeholder\\:foo`

Input: `title:john AND "developers meeting"`
Output: `+title:john AND "developers meeting"`

Making sure each of the keywords is required in the output will be left up to Elastic search using `default_operator=AND` if necessary.