### PR TITLE
Citadel: Make thread counts configurable

### DIFF
--- a/citadel/indico_citadel/cli.py
+++ b/citadel/indico_citadel/cli.py
@@ -42,7 +42,8 @@ def upload(batch, force, max_size):
         print('Citadel is not properly configured.')
         return
 
-    total, errors, aborted = backend.run_export_files(batch, force, max_size=max_size)
+    initial = not agent.settings.get('file_upload_done')
+    total, errors, aborted = backend.run_export_files(batch, force, max_size=max_size, initial=initial)
     if not errors and not aborted:
         print(f'{total} files uploaded')
         if max_size is None:

--- a/citadel/indico_citadel/plugin.py
+++ b/citadel/indico_citadel/plugin.py
@@ -36,6 +36,18 @@ class CitadelSettingsForm(IndicoForm):
                                                'for indexing that have not been uploaded before during the next queue '
                                                'run, which may take a long time on larger instances. You may want '
                                                'to run a manual upload for the new file size first!'))
+    num_threads_records = IntegerField(_('Parallel threads (records)'), [NumberRange(min=1, max=500)],
+                                       description=_('Number of threads to use when uploading records.'))
+    num_threads_records_initial = IntegerField(_('Parallel threads (records, initial export)'),
+                                               [NumberRange(min=1, max=500)],
+                                               description=_('Number of threads to use when uploading records during '
+                                                             'the initial export.'))
+    num_threads_files = IntegerField(_('Parallel threads (files)'), [NumberRange(min=1, max=500)],
+                                     description=_('Number of threads to use when uploading files.'))
+    num_threads_files_initial = IntegerField(_('Parallel threads (files, initial export)'),
+                                             [NumberRange(min=1, max=500)],
+                                             description=_('Number of threads to use when uploading files during '
+                                                           'the initial export.'))
     disable_search = BooleanField(_('Disable search'), widget=SwitchWidget(),
                                   description=_('This disables the search integration of the plugin. When this option '
                                                 'is used, the internal Indico search interface will be used. This may '
@@ -60,6 +72,10 @@ class CitadelPlugin(LiveSyncPluginBase):
             'tex', 'txt', 'wdp'
         ],
         'max_file_size': 10,
+        'num_threads_records': 5,
+        'num_threads_records_initial': 25,
+        'num_threads_files': 5,
+        'num_threads_files_initial': 25,
         'disable_search': False,
     }
     backend_classes = {'citadel': LiveSyncCitadelBackend}

--- a/livesync/indico_livesync/uploader.py
+++ b/livesync/indico_livesync/uploader.py
@@ -61,12 +61,13 @@ class Uploader:
             lambda entry: re.sub(r'\s+', ' ', strip_control_chars(getattr(entry[0], 'title', ''))),
             print_total_time=True
         )
-        return self.upload_records(records)
+        return self.upload_records(records, initial=True)
 
-    def upload_records(self, records):
+    def upload_records(self, records, initial=False):
         """Executed for a batch of up to `BATCH_SIZE` records
 
         :param records: an iterator of records to upload (or queue entries)
+        :param initial: whether the upload is part of an initial export
         :return: True if everything was successful, False if not
         """
         raise NotImplementedError  # pragma: no cover

--- a/livesync/tests/uploader_test.py
+++ b/livesync/tests/uploader_test.py
@@ -20,7 +20,7 @@ class RecordingUploader(Uploader):
         self._uploaded = []
         self.logger = MagicMock()
 
-    def upload_records(self, records):
+    def upload_records(self, records, initial=False):
         self._uploaded.append(list(records))
 
     @property
@@ -34,7 +34,7 @@ class FailingUploader(RecordingUploader):
         super().__init__(*args, **kwargs)
         self._n = 0
 
-    def upload_records(self, records):
+    def upload_records(self, records, initial=False):
         super().upload_records(records)
         self._n += 1
         if self._n == 2:

--- a/livesync_debug/indico_livesync_debug/backend.py
+++ b/livesync_debug/indico_livesync_debug/backend.py
@@ -56,7 +56,7 @@ class DebugUploader(Uploader):
                 return schema.dump(obj)
         raise ValueError(f'unknown object ref: {obj}')
 
-    def upload_records(self, records):
+    def upload_records(self, records, initial=False):
         dumped_records = (
             (
                 type(rec).__name__, rec.id,


### PR DESCRIPTION
Smaller instances don't need hundreds of threads, and for regular queue runs we don't need that many threads either.

I also used lower retry limits for regular queue runs since they just restart 15min later in case of a failure anyway.