### PR TITLE
LiveSync: Correctly cascade deletions after cloning

### DIFF
--- a/livesync/tests/uploader_test.py
+++ b/livesync/tests/uploader_test.py
@@ -53,7 +53,7 @@ def test_run_initial(mocker):
     assert not uploader.processed_records.called
 
 
-def _sorted_process_cascaded_event_contents(records, additional_events=None):
+def _sorted_process_cascaded_event_contents(records, additional_events=None, *, include_deleted=False):
     return sorted(_process_cascaded_event_contents(records, additional_events), key=attrgetter('id'))
 
 


### PR DESCRIPTION
When cloning an event, there's just a creation record for the event itself, but cascading creates creation records for all its child objects (e.g. contributions).
Now, when such a contribution gets deleted WITHOUT a livesync run in between, we have the event creation record and a contribution deletion record. But when cascading the creation, usually deleted objects are skipped, so we'd try to delete something from the search service that doesn't exist there.

With this change we cascade creations even to deleted child objects, so the implicit creation and the explicit deletion cancel itself out as expected.