### PR TITLE
LiveSync: Add setting to skip category queue entries

### DIFF
--- a/citadel/indico_citadel/backend.py
+++ b/citadel/indico_citadel/backend.py
@@ -310,8 +310,8 @@ class LiveSyncCitadelBackend(LiveSyncBackendBase):
         query = super().get_data_query(model_cls, ids)
         return query.options(joinedload(model_cls.citadel_id_mapping))
 
-    def process_queue(self, uploader):
-        super().process_queue(uploader)
+    def process_queue(self, uploader, allowed_categories=()):
+        super().process_queue(uploader, allowed_categories)
         uploader_name = type(uploader).__name__
         self.plugin.logger.info(f'{uploader_name} starting file upload')
         total, errors, aborted = self.run_export_files(verbose=False)

--- a/livesync/indico_livesync/plugin.py
+++ b/livesync/indico_livesync/plugin.py
@@ -35,6 +35,11 @@ class SettingsForm(IndicoForm):
                                                            "subcategories are excluded."))
     disable_queue_runs = BooleanField(_('Disable queue runs'), widget=SwitchWidget(),
                                       description=_('Disable all scheduled queue runs.'))
+    skip_category_changes = BooleanField(_('Skip category changes'), widget=SwitchWidget(),
+                                         description=_('Skip category changes when processing the queue. This can be '
+                                                       'useful in large instances when there are significant changes '
+                                                       'to large categories in order to avoid processing those '
+                                                       'immediately.'))
 
 
 class LiveSyncPlugin(IndicoPlugin):
@@ -47,7 +52,8 @@ class LiveSyncPlugin(IndicoPlugin):
     settings_form = SettingsForm
     default_settings = {'excluded_categories': [],
                         'queue_entry_ttl': 0,
-                        'disable_queue_runs': False}
+                        'disable_queue_runs': False,
+                        'skip_category_changes': False}
     category = PluginCategory.synchronization
 
     def init(self):

--- a/livesync_debug/indico_livesync_debug/backend.py
+++ b/livesync_debug/indico_livesync_debug/backend.py
@@ -77,8 +77,8 @@ class LiveSyncDebugBackend(LiveSyncBackendBase):
 
     uploader = DebugUploader
 
-    def process_queue(self, uploader):
-        records = self.fetch_records()
+    def process_queue(self, uploader, allowed_categories=()):
+        records = self.fetch_records(allowed_categories)
         if not records:
             print(cformat('%{yellow!}No records%{reset}'))
             return


### PR DESCRIPTION
Those can result in huge (hundred thousands of updates) in case of larger instances like ours, so when someone is making large changes we may want to pause processing them and wait until all changes to a set of categories are done, and also have the ability to run those in foreground instead of during the regular queue runs.

Also fixed a bug where we were cascading category changes to events in blacklisted categories.