### PR TITLE
Fixes for unlisted events on livesync plugin

### DIFF
--- a/livesync/indico_livesync/handler.py
+++ b/livesync/indico_livesync/handler.py
@@ -94,14 +94,14 @@ def _moved(obj, old_parent, **kwargs):
     _register_change(obj, ChangeType.moved)
 
     new_category = obj if isinstance(obj, Category) else obj.category
-    old_excluded = _is_category_excluded(old_parent)
+    old_excluded = _is_category_excluded(old_parent) if old_parent else False
     new_excluded = _is_category_excluded(new_category)
     if old_excluded != new_excluded:
         _register_change(obj, ChangeType.unpublished if new_excluded else ChangeType.published)
 
     if obj.is_inheriting:
         # If protection is inherited, check whether it changed
-        category_protection = old_parent.effective_protection_mode
+        category_protection = old_parent.effective_protection_mode if old_parent else None
         new_category_protection = obj.protection_parent.effective_protection_mode
         # Protection of new parent is different
         if category_protection != new_category_protection:

--- a/livesync/indico_livesync/handler.py
+++ b/livesync/indico_livesync/handler.py
@@ -115,9 +115,6 @@ def _moved(obj, old_parent, **kwargs):
 def _created(obj, **kwargs):
     if not isinstance(obj, (Event, EventNote, Attachment, Contribution, SubContribution)):
         raise TypeError(f'Unexpected object: {type(obj).__name__}')
-    # we don't care about unlisted events
-    if isinstance(obj, Event) and not obj.category:
-        return
     _register_change(obj, ChangeType.created)
 
 
@@ -166,9 +163,6 @@ def _protection_changed(sender, obj, **kwargs):
 
 
 def _acl_entry_changed(sender, obj, entry, old_data, **kwargs):
-    # we don't care about unlisted events
-    if isinstance(obj, Event) and not obj.category:
-        return
     if not inspect(obj).persistent:
         return
     register = False

--- a/livesync/indico_livesync/models/queue.py
+++ b/livesync/indico_livesync/models/queue.py
@@ -286,12 +286,13 @@ class LiveSyncQueueEntry(db.Model):
                     return
             else:
                 event = obj.folder.event if isinstance(obj, Attachment) else obj.event
-                if event.category:
-                    if event.category not in g.setdefault('livesync_excluded_categories_checked', {}):
-                        g.livesync_excluded_categories_checked[event.category] = \
-                            excluded_categories & set(event.category_chain)
-                    if g.livesync_excluded_categories_checked[event.category]:
-                        return
+                if event.is_unlisted:
+                    return
+                if event.category not in g.setdefault('livesync_excluded_categories_checked', {}):
+                    g.livesync_excluded_categories_checked[event.category] = \
+                        excluded_categories & set(event.category_chain)
+                if g.livesync_excluded_categories_checked[event.category]:
+                    return
 
         try:
             agents = g.livesync_agents

--- a/livesync/indico_livesync/models/queue.py
+++ b/livesync/indico_livesync/models/queue.py
@@ -286,11 +286,12 @@ class LiveSyncQueueEntry(db.Model):
                     return
             else:
                 event = obj.folder.event if isinstance(obj, Attachment) else obj.event
-                if event.category not in g.setdefault('livesync_excluded_categories_checked', {}):
-                    g.livesync_excluded_categories_checked[event.category] = \
-                        excluded_categories & set(event.category_chain)
-                if g.livesync_excluded_categories_checked[event.category]:
-                    return
+                if event.category:
+                    if event.category not in g.setdefault('livesync_excluded_categories_checked', {}):
+                        g.livesync_excluded_categories_checked[event.category] = \
+                            excluded_categories & set(event.category_chain)
+                    if g.livesync_excluded_categories_checked[event.category]:
+                        return
 
         try:
             agents = g.livesync_agents

--- a/livesync/setup.cfg
+++ b/livesync/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-livesync
-version = 3.0.1
+version = 3.1-dev
 description = Framework for pushing Indico event data to external services
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM
@@ -20,7 +20,7 @@ zip_safe = false
 include_package_data = true
 python_requires = ~=3.9.0
 install_requires =
-    indico>=3.0
+    indico>=3.1.dev0
 
 [options.entry_points]
 indico.plugins =


### PR DESCRIPTION
This PR adds `None` category checks for the livesync plugin.