### PR TITLE
Change bundle injection to WPConferenceDisplay

### DIFF
--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -19,7 +19,7 @@ from indico.core import signals
 from indico.core.auth import multipass
 from indico.core.errors import UserValueError
 from indico.core.plugins import IndicoPlugin, render_plugin_template, url_for_plugin
-from indico.modules.events.views import WPConferenceDisplayBase, WPSimpleEventDisplay
+from indico.modules.events.views import WPConferenceDisplay, WPSimpleEventDisplay
 from indico.modules.vc import VCPluginMixin, VCPluginSettingsFormBase
 from indico.modules.vc.exceptions import VCRoomError, VCRoomNotFoundError
 from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomStatus
@@ -160,7 +160,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         self.inject_bundle('main.js', WPSimpleEventDisplay)
         self.inject_bundle('main.js', WPVCEventPage)
         self.inject_bundle('main.js', WPVCManageEvent)
-        self.inject_bundle('main.js', WPConferenceDisplayBase)
+        self.inject_bundle('main.js', WPConferenceDisplay)
 
     @property
     def logo_url(self):


### PR DESCRIPTION
Comes from https://github.com/indico/indico-plugins/pull/157#discussion_r739575233. Avoids duplicated bundle in the videoconference page.