### PR TITLE
Add a plugin list parameter to the i18n script

### DIFF
--- a/manage-i18n.sh
+++ b/manage-i18n.sh
@@ -6,7 +6,7 @@
 # them and/or modify them under the terms of the MIT License;
 # see the LICENSE file for more details.
 
-USAGE="$0 [init <locale>|extract|update <locale>|compile <locale>]"
+USAGE="$0 [init <locale>|extract|update <locale>|compile <locale>] [plugin...]"
 
 if [[ $# -eq 0 || "$1" == '-h' || "$1" == '--help' ]]; then
     echo "$USAGE"
@@ -15,6 +15,12 @@ fi
 
 ACTION="$1"
 LOCALE="$2"
+PLUGINS=$(find . -name setup.py -exec sh -c 'basename $(dirname $0)' {} \;)
+PLUGINSINPARAMS=${@:3}
+
+if [[ ! -z $PLUGINSINPARAMS ]]; then
+    PLUGINS=$PLUGINSINPARAMS
+fi
 
 function require_locale {
     if [[ -z "$LOCALE" ]]; then
@@ -28,8 +34,9 @@ if [[ ! "init extract update compile" =~ $ACTION ]]; then
     exit 1
 fi
 
-for plugin in $(find . -name setup.py -exec sh -c 'basename $(dirname $0)' {} \;); do
+for plugin in $PLUGINS; do
     [[ "$plugin" == "_meta" ]] && continue
+    [[ ! -d "$plugin" ]] && echo "plugin not found $plugin" && continue
     pushd "${plugin}" >/dev/null
     if [[ "$ACTION" == "init" ]]; then
         require_locale

--- a/manage-i18n.sh
+++ b/manage-i18n.sh
@@ -36,7 +36,7 @@ fi
 
 for plugin in $PLUGINS; do
     [[ "$plugin" == "_meta" ]] && continue
-    [[ ! -d "$plugin" ]] && echo "plugin not found $plugin" && continue
+    [[ ! -d "$plugin" ]] && echo "plugin not found $plugin" && exit 1
     pushd "${plugin}" >/dev/null
     if [[ "$ACTION" == "init" ]]; then
         require_locale

--- a/manage-i18n.sh
+++ b/manage-i18n.sh
@@ -16,7 +16,12 @@ fi
 ACTION="$1"
 LOCALE="$2"
 PLUGINS=$(find . -name setup.py -exec sh -c 'basename $(dirname $0)' {} \;)
-PLUGINSINPARAMS=${@:3}
+
+if [[ "$ACTION" == "extract" ]]; then
+    PLUGINSINPARAMS=${@:2}
+else
+    PLUGINSINPARAMS=${@:3}
+fi
 
 if [[ ! -z $PLUGINSINPARAMS ]]; then
     PLUGINS=$PLUGINSINPARAMS
@@ -36,7 +41,7 @@ fi
 
 for plugin in $PLUGINS; do
     [[ "$plugin" == "_meta" ]] && continue
-    [[ ! -d "$plugin" ]] && echo "plugin not found $plugin" && exit 1
+    [[ ! -d "$plugin" ]] && echo "plugin $plugin not found" && exit 1
     pushd "${plugin}" >/dev/null
     if [[ "$ACTION" == "init" ]]; then
         require_locale


### PR DESCRIPTION
The new usage is:

```
./manage-i18n.sh [init <locale>|extract|update <locale>|compile <locale>] [plugin...]
```