### PR TITLE
Fix DeprecationWarning breaking tests

### DIFF
--- a/citadel/pytest.ini
+++ b/citadel/pytest.ini
@@ -12,5 +12,7 @@ filterwarnings =
     ignore::UserWarning
     # port_for via pytest-redis
     ignore:Sampling from a set deprecated:DeprecationWarning:port_for
+    # celery
+    ignore:Creating a LegacyVersion has been deprecated:DeprecationWarning
 ; use redis-server from $PATH
 redis_exec = redis-server

--- a/livesync/pytest.ini
+++ b/livesync/pytest.ini
@@ -12,5 +12,7 @@ filterwarnings =
     ignore::UserWarning
     # port_for via pytest-redis
     ignore:Sampling from a set deprecated:DeprecationWarning:port_for
+    # celery
+    ignore:Creating a LegacyVersion has been deprecated:DeprecationWarning
 ; use redis-server from $PATH
 redis_exec = redis-server

--- a/payment_paypal/pytest.ini
+++ b/payment_paypal/pytest.ini
@@ -12,5 +12,7 @@ filterwarnings =
     ignore::UserWarning
     # port_for via pytest-redis
     ignore:Sampling from a set deprecated:DeprecationWarning:port_for
+    # celery
+    ignore:Creating a LegacyVersion has been deprecated:DeprecationWarning
 ; use redis-server from $PATH
 redis_exec = redis-server

--- a/storage_s3/pytest.ini
+++ b/storage_s3/pytest.ini
@@ -12,5 +12,7 @@ filterwarnings =
     ignore::UserWarning
     # port_for via pytest-redis
     ignore:Sampling from a set deprecated:DeprecationWarning:port_for
+    # celery
+    ignore:Creating a LegacyVersion has been deprecated:DeprecationWarning
 ; use redis-server from $PATH
 redis_exec = redis-server

--- a/vc_zoom/pytest.ini
+++ b/vc_zoom/pytest.ini
@@ -12,5 +12,7 @@ filterwarnings =
     ignore::UserWarning
     # port_for via pytest-redis
     ignore:Sampling from a set deprecated:DeprecationWarning:port_for
+    # celery
+    ignore:Creating a LegacyVersion has been deprecated:DeprecationWarning
 ; use redis-server from $PATH
 redis_exec = redis-server


### PR DESCRIPTION
Celery is using an invalid legacy version specifier (celery/celery#7074)