### PR TITLE
Storage/S3: Fix "Invalid Signature" s3 error w/ nginx

### DIFF
--- a/storage_s3/README.md
+++ b/storage_s3/README.md
@@ -15,6 +15,10 @@ to local storage (but it would of course be possible to write a script for this)
 
 ## Changelog
 
+### 3.1
+
+- Fix "invalid signature" S3 error in some cases when using `proxy=nginx` for downloads
+
 ### 3.0
 
 - Initial release for Indico 3.0

--- a/storage_s3/indico_storage_s3/storage.py
+++ b/storage_s3/indico_storage_s3/storage.py
@@ -20,6 +20,7 @@ from boto3.s3.transfer import TransferConfig
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from werkzeug.datastructures import Headers
+from werkzeug.urls import url_quote
 from werkzeug.utils import cached_property, redirect
 
 from indico.core.config import config
@@ -155,7 +156,7 @@ class S3StorageBase(Storage):
             if self.proxy_downloads == ProxyDownloadsMode.nginx:
                 # nginx can proxy the request to S3 to avoid exposing the redirect and
                 # bucket URL to the end user (since it is quite ugly and temporary)
-                response.headers['X-Accel-Redirect'] = '/.xsf/s3/' + url.replace('://', '/', 1)
+                response.headers['X-Accel-Redirect'] = '/.xsf/s3/' + url_quote(url.replace('://', '/', 1))
             return response
         except Exception as exc:
             raise StorageError(f'Could not send file "{file_id}": {exc}') from exc

--- a/storage_s3/setup.cfg
+++ b/storage_s3/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-storage-s3
-version = 3.0
+version = 3.1
 description = S3 storage backend for Indico
 url = https://github.com/indico/indico-plugins
 license = MIT
@@ -18,8 +18,8 @@ zip_safe = false
 include_package_data = true
 python_requires = ~=3.9.0
 install_requires =
-    indico>=3.0
-    boto3>=1.14.30,<2.0
+    indico>=3.1
+    boto3>=1.20.51,<2.0
 
 [options.entry_points]
 indico.plugins =


### PR DESCRIPTION
This happened in some cases when using proxy=nginx if the signature ended up containing an url-encoded character, since apparently nginx url-decodes it once, and then the URL forwarded to S3 by nginx no longer matched the signature.

Also bumped the version to 3.1 and require an up to date Indico + boto3 version