### PR TITLE
Do not inject zoom links in HTTP API responses

### DIFF
--- a/vc_zoom/README.md
+++ b/vc_zoom/README.md
@@ -11,6 +11,12 @@
 
 ## Changelog
 
+### 3.1.2
+
+- Do not include Zoom link in event descriptions returned by the HTTP API (iCalendar files for
+  events and categories are no longer generated through the API and other consumers of the API
+  typically do not expect Zoom links in there)
+
 ### 3.1.1
 
 - Fix processing webhooks for Zoom meetings updated/deleted outside Indico

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -153,7 +153,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         super().init()
         self.connect(signals.plugin.cli, self._extend_indico_cli)
         self.connect(signals.event.times_changed, self._times_changed)
-        self.connect(signals.event.metadata_postprocess, self._event_metadata_postprocess)
+        self.connect(signals.event.metadata_postprocess, self._event_metadata_postprocess, sender='ical-export')
         self.template_hook('event-vc-room-list-item-labels', self._render_vc_room_labels)
         self.inject_bundle('main.js', WPSimpleEventDisplay)
         self.inject_bundle('main.js', WPVCEventPage)

--- a/vc_zoom/setup.cfg
+++ b/vc_zoom/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-vc-zoom
-version = 3.1.1
+version = 3.1.2
 description = Zoom video-conferencing plugin for Indico
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM


### PR DESCRIPTION
iCalendar files for events and categories are no longer generated through the API in recent Indico versions and other consumers of the API (scripts etc) typically do not expect Zoom links in there.