### PR TITLE
Create a task to reschedule zoom meetings

### DIFF
--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -528,9 +528,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
 
         @after_this_request
         def _launch_task(response):
-            prev_dt = obj.start_dt
-            refresh_meetings.delay(zoom_rooms, obj.start_dt, log_entry, int(obj.duration.seconds / 60),
-                                   lambda: obj.start_dt == prev_dt)
+            refresh_meetings.delay(zoom_rooms, obj, log_entry)
             return response
 
     def _render_vc_room_labels(self, event, vc_room, **kwargs):

--- a/vc_zoom/indico_vc_zoom/task.py
+++ b/vc_zoom/indico_vc_zoom/task.py
@@ -18,14 +18,12 @@ def update_state_log(log_entry, failed):
 
 
 @celery.task(plugin='vc_zoom', autoretry_for=(HTTPError,))
-def refresh_meetings(vc_rooms, target_dt, log_entry=None, duration=None, condition=None):
+def refresh_meetings(vc_rooms, obj, log_entry=None):
     from indico_vc_zoom.api import ZoomIndicoClient
-    if condition and not condition():
-        return
     client = ZoomIndicoClient()
     failed = False
-    payload = {'start_time': target_dt}
-    if duration:
+    payload = {'start_time': obj.start_dt}
+    if duration := int(obj.duration.total_seconds() / 60):
         payload['duration'] = duration
     try:
         for vc_room in vc_rooms:


### PR DESCRIPTION
These changes help the zoom meetings cope with event (or contribution, session) `start_dt` changes which could potentially lead to expired meetings for postponed events. The logic is the following:
- When an event is anticipated, meetings remain untouched as they only expire on a future date.
- When an event is postponed, we need to check if the new date is close to the video-conference room expiration, by comparing it with **the original** scheduled date.

For point number 2, I've considered that all meetings part of an event should always be scheduled for the exact same date. Using one of them, we query zoom for its original scheduled date. To conclude, we check if the new event date is 30 days after the former ensuring postponing multiple times won't lead to unnecessary updates.

Might close #170 