### PR TITLE
OwnCloud: Add configuration params to file-picker URL

### DIFF
--- a/owncloud/README.md
+++ b/owncloud/README.md
@@ -1,10 +1,24 @@
 # OwnCloud integration plugin
 
-This plugin enables integration with an ownCloud server, initially for the
-purpose of attaching materials to an event or category. A new "from the cloud"
-button shows up in the materials section which enables a manager to log into his
-ownCloud account and pick files from his personal storage. Those files will be
-copied as attachments.
+This plugin enables integration with an ownCloud server, for the purpose of
+attaching materials to an event or category. A new "from the cloud" button
+shows up in the materials section which enables managers to log into their
+ownCloud account and pick files from their personal storage. Those files will
+be copied as attachments.
+
+## Setting up the ownCloud File-picker
+
+This plugin uses an external [File-picker](https://github.com/owncloud/file-picker)
+iframe.
+
+It is recommended to set up the File-picker server in the same domain as the
+ownCloud instance, to facilitate authentication. CERNBox provides
+[a wrapper](https://github.com/cernbox/file-picker-wrapper) with a slightly
+modified File-picker which handles message passing to the parent app as well as
+different styling and configuration options.
+
+You can also check out [the docs](https://filepicker.cernbox.cern.ch/docs/) for
+it.
 
 ## Changelog
 

--- a/owncloud/indico_owncloud/templates/owncloud_filepicker_widget.html
+++ b/owncloud/indico_owncloud/templates/owncloud_filepicker_widget.html
@@ -1,7 +1,7 @@
 {% extends 'forms/base_widget.html' %}
 
 {% block html %}
-    {% set src = field.filepicker_url + '?origin=' + field.origin %}
+    {% set src = field.filepicker_url + '?userHome=1&style=indico&origin=' + field.origin %}
     <div class="i-form-field-fixed-width">
         <input type="hidden" name="{{ field.name }}" id="{{ field.id }}-files" {{ input_args | html_params }}>
         <span id="{{ field.id }}-container">


### PR DESCRIPTION
This PR adds the `userHome` and `style` search params to the Indico OwnCloud plugin file-picker iframe so it starts in the user home instead of eos root, and uses the Indico CSS.