### PR TITLE
Disable add files button when not ready

### DIFF
--- a/owncloud/README.md
+++ b/owncloud/README.md
@@ -22,6 +22,11 @@ it.
 
 ## Changelog
 
+## 3.2.1
+
+- Disable the confirmation button in the 'add files' dialog if the File-picker
+  is working or selection is empty
+
 ### 3.2
 
 - Initial release for Indico 3.2

--- a/owncloud/indico_owncloud/client/index.js
+++ b/owncloud/indico_owncloud/client/index.js
@@ -9,6 +9,10 @@
 window.setupOwncloudFilePickerWidget = ({filepickerUrl, fieldId}) => {
   window.addEventListener('message', message => {
     const iframe = document.querySelector('#owncloud_filepicker-file-picker');
+    const submitButton = document.querySelector(
+      '#attachment-owncloudfilepicker-form input[type=submit]'
+    );
+
     if (
       iframe &&
       message.origin === filepickerUrl &&
@@ -17,6 +21,7 @@ window.setupOwncloudFilePickerWidget = ({filepickerUrl, fieldId}) => {
       message.data.files
     ) {
       document.getElementById(`${fieldId}-files`).value = message.data.files.join('\n');
+      submitButton.disabled = !message.data.ready || !message.data.files.length;
     }
   });
 };

--- a/owncloud/indico_owncloud/forms.py
+++ b/owncloud/indico_owncloud/forms.py
@@ -34,7 +34,7 @@ class AttachmentOwncloudFormMixin:
 
     def validate_owncloud_filepicker(self, field):
         if self.owncloud_filepicker.data and self.owncloud_filepicker.data['files'] == ['']:
-            raise ValidationError("Select files to add and click 'Select resources'")
+            raise ValidationError('Select some files')
 
 
 class AddAttachmentOwncloudForm(AttachmentOwncloudFormMixin, AttachmentFormBase):

--- a/owncloud/indico_owncloud/templates/owncloud_filepicker_widget.html
+++ b/owncloud/indico_owncloud/templates/owncloud_filepicker_widget.html
@@ -12,6 +12,7 @@
 
 {% block javascript %}
     <script>
+        document.querySelector('#attachment-owncloudfilepicker-form input[type=submit]').disabled = true;
         setupOwncloudFilePickerWidget({
             filepickerUrl: {{ field.filepicker_url | tojson }},
             fieldId: {{ field.id | tojson }},

--- a/owncloud/setup.cfg
+++ b/owncloud/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-owncloud
-version = 3.2
+version = 3.2.1
 description = Integrates ownCloud storage as a source for materials
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM


### PR DESCRIPTION
This PR disables the 'Add' button in the 'Add files' dialog for the ownCloud plugin while the File-picker is performing async operations.

This fixes the bug caused by a user clicking too fast on "Add" after selecting a file, where he would get notified that there are no files selected.