### PR TITLE
Fix 'Mute video (host)' in room settings

### DIFF
--- a/vc_zoom/README.md
+++ b/vc_zoom/README.md
@@ -11,6 +11,10 @@
 
 ## Changelog
 
+### 3.2.2
+
+- Correctly show current "Mute video (host)" status when editing zoom meeting
+
 ### 3.2.1
 
 - Do not break Zoom meetings that require registration when cloning or attaching to another event

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -418,7 +418,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             'description': zoom_meeting.get('agenda', ''),
             'zoom_id': zoom_meeting['id'],
             'password': zoom_meeting['password'],
-            'mute_host_video': zoom_meeting['settings']['host_video'],
+            'mute_host_video': not zoom_meeting['settings']['host_video'],
 
             # these options will be empty for webinars
             'mute_audio': zoom_meeting['settings'].get('mute_upon_entry'),

--- a/vc_zoom/setup.cfg
+++ b/vc_zoom/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-vc-zoom
-version = 3.2.1
+version = 3.2.2
 description = Zoom video-conferencing plugin for Indico
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM


### PR DESCRIPTION
`mute_host_video` is the negation of zoom's `host_video`.