### PR TITLE
[cloud_captchas] Import translation components from Indico

### DIFF
--- a/cloud_captchas/indico_cloud_captchas/client/i18n.js
+++ b/cloud_captchas/indico_cloud_captchas/client/i18n.js
@@ -10,4 +10,4 @@ import {bindTranslateComponents} from 'indico/react/i18n';
 const {Translate, PluralTranslate} = bindTranslateComponents('cloud_captchas');
 
 export {Translate, PluralTranslate};
-export {Singular, Plural, Param} from 'react-jsx-i18n';
+export {Singular, Plural, Param} from 'indico/react/i18n';


### PR DESCRIPTION
When `Param` is imported directly from `react-jsx-i18n`, webpack probably creates a different instance
which leads to this error when running it (originally found by Duarte):

https://github.com/indico/react-jsx-i18n/blob/4b62533d907c2ae6356db6a1a65c1f64860bb90f/src/client/index.js#L42C38-L42C38

