### PR TITLE
Citadel: Implement warning threshold

### DIFF
--- a/citadel/MANIFEST.in
+++ b/citadel/MANIFEST.in
@@ -1,4 +1,5 @@
 graft indico_citadel/migrations
+graft indico_citadel/templates
 graft indico_citadel/translations
 
 global-exclude *.pyc __pycache__ .keep

--- a/citadel/README.md
+++ b/citadel/README.md
@@ -9,6 +9,8 @@ to provide advanced search functionality using an Elasticsearch backend.
 
 - Adapt to Indico 3.3 changes
 - Support Python 3.12
+- Add option to show a warning in large categories, encourating managers to use groups instead of
+  individual ACL entries (to avoid having to re-send huge amounts of data to the backend)
 
 ### 3.2.2
 

--- a/citadel/indico_citadel/plugin.py
+++ b/citadel/indico_citadel/plugin.py
@@ -102,7 +102,5 @@ class CitadelPlugin(LiveSyncPluginBase):
 
     def _check_event_categories(self, category):
         threshold = self.settings.get('large_category_warning_threshold')
-        num_events = category.deep_events_count
-
-        if threshold and num_events > threshold:
+        if threshold and category.deep_events_count > threshold:
             return render_plugin_template('event_category_warning.html')

--- a/citadel/indico_citadel/plugin.py
+++ b/citadel/indico_citadel/plugin.py
@@ -18,6 +18,7 @@ from indico_citadel import _
 from indico_citadel.backend import LiveSyncCitadelBackend
 from indico_citadel.cli import cli
 from indico_livesync import LiveSyncPluginBase
+from indico_citadel.util import check_event_categories
 
 
 class CitadelSettingsForm(IndicoForm):
@@ -51,6 +52,12 @@ class CitadelSettingsForm(IndicoForm):
                                                 'is used, the internal Indico search interface will be used. This may '
                                                 'be useful when you are still running a larger initial export and do '
                                                 'not want people to get incomplete search results during that time.'))
+    large_category_warning_threshold = IntegerField(_('Large Category Warning Threshold'),
+                                                    [NumberRange(min=0)],
+                                                    description=_('This shows a warning message to admins when '
+                                                                  'the number of events in a category surpasses '
+                                                                  'the threshold set here. You can set the '
+                                                                  'threshold to 0 to suppress this warning.'))
 
 
 class CitadelPlugin(LiveSyncPluginBase):
@@ -75,6 +82,7 @@ class CitadelPlugin(LiveSyncPluginBase):
         'num_threads_files': 5,
         'num_threads_files_initial': 25,
         'disable_search': False,
+        'large_category_warning_threshold': 0,
     }
     backend_classes = {'citadel': LiveSyncCitadelBackend}
 
@@ -82,6 +90,7 @@ class CitadelPlugin(LiveSyncPluginBase):
         super().init()
         self.connect(signals.core.get_search_providers, self.get_search_providers)
         self.connect(signals.plugin.cli, self._extend_indico_cli)
+        self.template_hook('category-protection-page', check_event_categories)
 
     def get_search_providers(self, sender, **kwargs):
         from indico_citadel.search import CitadelProvider

--- a/citadel/indico_citadel/plugin.py
+++ b/citadel/indico_citadel/plugin.py
@@ -54,10 +54,11 @@ class CitadelSettingsForm(IndicoForm):
                                                 'not want people to get incomplete search results during that time.'))
     large_category_warning_threshold = IntegerField(_('Large Category Warning Threshold'),
                                                     [NumberRange(min=0)],
-                                                    description=_('This shows a warning message to admins when '
-                                                                  'the number of events in a category surpasses '
-                                                                  'the threshold set here. You can set the '
-                                                                  'threshold to 0 to suppress this warning.'))
+                                                    description=_('Displays a warning to category managers when '
+                                                                  'changing the ACL of big categories that would '
+                                                                  'result in sending a large amount of data to '
+                                                                  'the Citadel server. You can set the threshold '
+                                                                  'to 0 to suppress this warning.'))
 
 
 class CitadelPlugin(LiveSyncPluginBase):
@@ -90,7 +91,7 @@ class CitadelPlugin(LiveSyncPluginBase):
         super().init()
         self.connect(signals.core.get_search_providers, self.get_search_providers)
         self.connect(signals.plugin.cli, self._extend_indico_cli)
-        self.template_hook('category-protection-page', self.check_event_categories)
+        self.template_hook('category-protection-page', self._check_event_categories)
 
     def get_search_providers(self, sender, **kwargs):
         from indico_citadel.search import CitadelProvider
@@ -99,7 +100,7 @@ class CitadelPlugin(LiveSyncPluginBase):
     def _extend_indico_cli(self, sender, **kwargs):
         return cli
 
-    def check_event_categories(self, category):
+    def _check_event_categories(self, category):
         threshold = self.settings.get('large_category_warning_threshold')
         num_events = category.deep_events_count
 

--- a/citadel/indico_citadel/templates/event_category_warning.html
+++ b/citadel/indico_citadel/templates/event_category_warning.html
@@ -1,8 +1,10 @@
 {% from 'message_box.html' import message_box %}
 
 {% call message_box('warning', large_icon=true, fixed_width=true) %}
-    <strong>{% trans -%}This category contains a large number of events.{%- endtrans %}</strong>
+    <strong>{% trans %}This category contains a large number of events.{% endtrans %}</strong>
     <br>
-    {% trans -%}Please consider using groups instead of individual users when granting access to management privileges
-    since any change to the ACL requires re-synchronizing all events with Indico's search engine.{%- endtrans %}
+    {% trans -%}
+        Please consider using groups instead of individual users when granting access or management permissions
+        since any change to the list below requires re-synchronizing all events with Indico's search engine.
+    {%- endtrans %}
 {% endcall %}

--- a/citadel/indico_citadel/templates/event_category_warning.html
+++ b/citadel/indico_citadel/templates/event_category_warning.html
@@ -1,10 +1,8 @@
 {% from 'message_box.html' import message_box %}
 
 {% call message_box('warning', large_icon=true, fixed_width=true) %}
-    {% trans -%}
-        <b>This category contains a large number of events.</b>
-        <br/>
-        Please consider using groups instead of individual users when granting access or management privileges
-        since any change to the access control list requires re-synchronizing all events with Indico's search engine.
-    {%- endtrans %}
+    <strong>{% trans -%}This category contains a large number of events.{%- endtrans %}</strong>
+    <br>
+    {% trans -%}Please consider using groups instead of individual users when granting access to management privileges
+    since any change to the ACL requires re-synchronizing all events with Indico's search engine.{%- endtrans %}
 {% endcall %}

--- a/citadel/indico_citadel/templates/event_category_warning.html
+++ b/citadel/indico_citadel/templates/event_category_warning.html
@@ -1,9 +1,10 @@
 {% from 'message_box.html' import message_box %}
 
 {% call message_box('warning', large_icon=true, fixed_width=true) %}
-    {% trans category_title=category.title, max_events_threshold=threshold -%}
-        <b>The '{{ category_title }}' category contains over {{ max_events_threshold }} events - this may cause performance issues.</b>
+    {% trans -%}
+        <b>This category contains a large number of events.</b>
         <br/>
-        Please consider using groups instead of individual users to avoid having to re-send large amounts of changes to users individually.
+        Please consider using groups instead of individual users when granting access or management privileges
+        since any change to the access control list requires re-synchronizing all events with Indico's search engine.
     {%- endtrans %}
 {% endcall %}

--- a/citadel/indico_citadel/templates/event_category_warning.html
+++ b/citadel/indico_citadel/templates/event_category_warning.html
@@ -1,0 +1,9 @@
+{% from 'message_box.html' import message_box %}
+
+{% call message_box('warning', large_icon=true, fixed_width=true) %}
+    {% trans category_title=category.title, max_events_threshold=threshold -%}
+        <b>The '{{ category_title }}' category contains over {{ max_events_threshold }} events - this may cause performance issues.</b>
+        <br/>
+        Please consider using groups instead of individual users to avoid having to re-send large amounts of changes to users individually.
+    {%- endtrans %}
+{% endcall %}

--- a/citadel/indico_citadel/util.py
+++ b/citadel/indico_citadel/util.py
@@ -13,6 +13,7 @@ from functools import wraps
 
 from flask import current_app
 from flask.globals import _cv_app
+from flask_pluginengine.plugin import render_plugin_template
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy.principals import PrincipalMixin, PrincipalPermissionsMixin, PrincipalType
@@ -215,3 +216,13 @@ def get_user_access(user, admin_override_enabled=False):
                             for x in user.iter_all_multipass_groups()]
         access += _include_capitalized_groups(multipass_groups)
     return access
+
+
+def check_event_categories(category):
+    from indico_citadel.plugin import CitadelPlugin
+
+    threshold = CitadelPlugin.settings.get('large_category_warning_threshold')
+    num_events = category.deep_events_count
+
+    if threshold and num_events > threshold:
+        return render_plugin_template('event_category_warning.html', category=category, threshold=threshold)

--- a/citadel/indico_citadel/util.py
+++ b/citadel/indico_citadel/util.py
@@ -13,7 +13,6 @@ from functools import wraps
 
 from flask import current_app
 from flask.globals import _cv_app
-from flask_pluginengine.plugin import render_plugin_template
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy.principals import PrincipalMixin, PrincipalPermissionsMixin, PrincipalType
@@ -216,13 +215,3 @@ def get_user_access(user, admin_override_enabled=False):
                             for x in user.iter_all_multipass_groups()]
         access += _include_capitalized_groups(multipass_groups)
     return access
-
-
-def check_event_categories(category):
-    from indico_citadel.plugin import CitadelPlugin
-
-    threshold = CitadelPlugin.settings.get('large_category_warning_threshold')
-    num_events = category.deep_events_count
-
-    if threshold and num_events > threshold:
-        return render_plugin_template('event_category_warning.html', category=category, threshold=threshold)


### PR DESCRIPTION
This PR implements a warning message that is displayed to category admins when the total count of events in said category goes over a configurable threshold. The warning message will recommend admins to use groups instead.

TODO:
- [x] Configurable event warning threshold (plugin settings)
- [x] Better/More informative message (with styling)
- [x] Cleanup/Refactor

Preview:
![image](https://github.com/indico/indico-plugins/assets/7736654/db419a21-8ba9-4a10-a417-514184050ab3)

