### PR TITLE
fix saferpay: new saferpay ids are one digit longer

### DIFF
--- a/payment_sixpay/README.md
+++ b/payment_sixpay/README.md
@@ -11,6 +11,7 @@ they are automatically sent back to Indico.
 ### 3.3.1
 
 - Update iso4217 dependency
+- Support longer Saferpay account IDs
 
 ### 3.3
 

--- a/payment_sixpay/indico_payment_sixpay/forms.py
+++ b/payment_sixpay/indico_payment_sixpay/forms.py
@@ -110,10 +110,10 @@ class PluginSettingsForm(PaymentPluginSettingsFormBase):
         label=_('Account ID'),
         validators=[
             Optional(),
-            IndicoRegexp(r'^[0-9-]{0,15}$')
+            IndicoRegexp(r'^[0-9-]{0,16}$')
         ],
         description=_(
-            'Default Saferpay account ID, such as "123456-12345678". '
+            'Default Saferpay account ID, such as "1234567-12345678". '
             'Event managers will be able to override this.'
         )
     )
@@ -154,9 +154,9 @@ class EventSettingsForm(PaymentEventSettingsFormBase):
         label=_('Account ID'),
         validators=[
             DataRequired(),
-            IndicoRegexp(r'^[0-9-]{0,15}$')
+            IndicoRegexp(r'^[0-9-]{0,16}$')
         ],
-        description=_('The Saferpay account ID, such as "123456-12345678".')
+        description=_('The Saferpay account ID, such as "1234567-12345678".')
     )
     order_description = StringField(
         label=_('Order Description'),


### PR DESCRIPTION
Hi, we received a new saferpay id last week. the new id is one digit longer than the validator supports. Don't think it will have negative impact on anyone having the validator allow one more digit.