### PR TITLE
Fix room name display in the compact theme

### DIFF
--- a/themes_legacy/README.md
+++ b/themes_legacy/README.md
@@ -15,6 +15,10 @@ using it when an instance is upgraded to 3.0.
 
 ## Changelog
 
+### 3.3.2
+
+- Do not show empty parentheses when a room is not set
+
 ### 3.3.1
 
 - Update translations

--- a/themes_legacy/indico_themes_legacy/templates/compact_timetable.html
+++ b/themes_legacy/indico_themes_legacy/templates/compact_timetable.html
@@ -44,7 +44,7 @@
 
             (until {{ block.timetable_entry.end_dt | format_time(timezone=timezone) }})
 
-            {% if not block.inherits_location %}
+            {% if not contrib.inherit_location and contrib.room_name %}
                 ({{ block.room_name }})
             {% endif %}
 

--- a/themes_legacy/indico_themes_legacy/templates/compact_timetable.html
+++ b/themes_legacy/indico_themes_legacy/templates/compact_timetable.html
@@ -76,7 +76,7 @@
 
             &nbsp;
 
-            {% if not contrib.inherits_location %}
+            {% if not contrib.inherit_location and contrib.room_name  %}
                 ({{ contrib.room_name }})
             {% endif %}
             <div style="float: right">

--- a/themes_legacy/pyproject.toml
+++ b/themes_legacy/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'indico-plugin-themes-legacy'
 description = 'Framework for pushing Indico event data to external services'
 readme = 'README.md'
-version = '3.3.1'
+version = '3.3.2'
 license = 'MIT'
 authors = [{ name = 'Indico Team', email = 'indico-team@cern.ch' }]
 classifiers = [


### PR DESCRIPTION
There are some extra empty parens when the room name is not set.

now:
![image](https://github.com/user-attachments/assets/00c186a0-9b1a-4600-a380-d4da7dd64ec6)

with the fix:
![image](https://github.com/user-attachments/assets/bf6fe92d-2646-40f3-b893-8f04ae6fd00e)
