### PR TITLE
Adapt plugins to signed user identifiers

### DIFF
--- a/citadel/README.md
+++ b/citadel/README.md
@@ -5,6 +5,10 @@ to provide advanced search functionality using an Elasticsearch backend.
 
 ## Changelog
 
+### 3.3.3
+
+- Adapt to Indico 3.3.7 changes
+
 ### 3.3.2
 
 - Update translations

--- a/citadel/indico_citadel/schemas.py
+++ b/citadel/indico_citadel/schemas.py
@@ -32,7 +32,7 @@ PRINCIPAL_TYPES = {
 
 
 def _get_identifiers(access_list):
-    return sorted(p.identifier for p in access_list if p.principal_type in PRINCIPAL_TYPES)
+    return sorted(p.persistent_identifier for p in access_list if p.principal_type in PRINCIPAL_TYPES)
 
 
 def _get_category_chain(event, categories):

--- a/citadel/indico_citadel/util.py
+++ b/citadel/indico_citadel/util.py
@@ -197,9 +197,9 @@ def _get_alternative_group_names():
 def _include_capitalized_groups(groups):
     alternatives = _get_alternative_group_names()
     for group in groups:
-        yield group.identifier
+        yield group.persistent_identifier
         for alt_name in alternatives.get((group.provider, group.name.lower()), ()):
-            yield GroupProxy(alt_name, group.provider).identifier
+            yield GroupProxy(alt_name, group.provider).persistent_identifier
 
 
 @memoize_redis(3600)
@@ -208,8 +208,8 @@ def get_user_access(user, admin_override_enabled=False):
         return []
     if admin_override_enabled and user.is_admin:
         return ['IndicoAdmin']
-    access = [user.identifier] + [u.identifier for u in user.get_merged_from_users_recursive()]
-    access += [GroupProxy(x.id, _group=x).identifier for x in user.local_groups]
+    access = [user.persistent_identifier] + [u.persistent_identifier for u in user.get_merged_from_users_recursive()]
+    access += [GroupProxy(x.id, _group=x).persistent_identifier for x in user.local_groups]
     if user.can_get_all_multipass_groups:
         multipass_groups = [GroupProxy(x.name, x.provider.name, x)
                             for x in user.iter_all_multipass_groups()]

--- a/citadel/pyproject.toml
+++ b/citadel/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'indico-plugin-citadel'
 description = 'Indico search+livesync backend using Citadel+ElasticSearch'
 readme = 'README.md'
-version = '3.3.2'
+version = '3.3.3'
 license = 'MIT'
 authors = [{ name = 'Indico Team', email = 'indico-team@cern.ch' }]
 classifiers = [
@@ -12,7 +12,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
 ]
 requires-python = '>=3.12.2, <3.13'
-dependencies = ['indico>=3.3', 'indico-plugin-livesync>=3.3.dev0']
+dependencies = ['indico>=3.3.7.dev0', 'indico-plugin-livesync>=3.3.dev0']
 
 [project.urls]
 GitHub = 'https://github.com/indico/indico-plugins'

--- a/vc_zoom/README.md
+++ b/vc_zoom/README.md
@@ -11,6 +11,10 @@
 
 ## Changelog
 
+### 3.3.4
+
+- Adapt to Indico 3.3.7 changes
+
 ### 3.3.3
 
 - Fix display issue if a Zoom meeting has its passcode visibility set to "no one"

--- a/vc_zoom/indico_vc_zoom/controllers.py
+++ b/vc_zoom/indico_vc_zoom/controllers.py
@@ -27,7 +27,7 @@ from indico.web.rh import RH
 
 class RHRoomAlternativeHost(RHVCSystemEventBase):
     def _process(self):
-        new_identifier = session.user.identifier
+        new_identifier = session.user.persistent_identifier
         if new_identifier == self.vc_room.data['host'] or new_identifier in self.vc_room.data['alternative_hosts']:
             raise UserValueError(_('You were already an (alternative) host of this meeting'))
 

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -88,7 +88,7 @@ class VCRoomForm(VCRoomFormBase):
     def __init__(self, *args, **kwargs):
         defaults = kwargs['obj']
         if defaults.host_user is None and defaults.host is not None:
-            host = principal_from_identifier(defaults.host)
+            host = principal_from_identifier(defaults.host, require_user_token=False)
             defaults.host_choice = 'myself' if host == session.user else 'someone_else'
             defaults.host_user = None if host == session.user else host
 
@@ -124,6 +124,6 @@ class VCRoomForm(VCRoomFormBase):
         if self.host_choice is None:
             return None
         elif self.host_choice.data == 'myself':
-            return session.user.identifier
+            return session.user.persistent_identifier
         else:
-            return self.host_user.data.identifier if self.host_user.data else None
+            return self.host_user.data.persistent_identifier if self.host_user.data else None

--- a/vc_zoom/indico_vc_zoom/notifications.py
+++ b/vc_zoom/indico_vc_zoom/notifications.py
@@ -13,7 +13,7 @@ from indico.web.flask.templating import get_template_module
 def notify_host_start_url(vc_room):
     from indico_vc_zoom.plugin import ZoomPlugin
 
-    user = principal_from_identifier(vc_room.data['host'])
+    user = principal_from_identifier(vc_room.data['host'], require_user_token=False)
     to_list = {user.email}
 
     template_module = get_template_module(

--- a/vc_zoom/indico_vc_zoom/templates/buttons.html
+++ b/vc_zoom/indico_vc_zoom/templates/buttons.html
@@ -50,8 +50,8 @@
             caption="{% trans %}Please log in{% endtrans %}"
         {% endif %}
 
-        {% if session.user.identifier != vc_room.data['host']
-           and session.user.identifier not in vc_room.data.get('alternative_hosts', [])
+        {% if session.user.persistent_identifier != vc_room.data['host']
+           and session.user.persistent_identifier not in vc_room.data.get('alternative_hosts', [])
            and event.can_manage(session.user) %}
              alt-host-url="{{ url_for_plugin('vc_zoom.make_me_alt_host', event_vc_room) }}"
         {% endif %}

--- a/vc_zoom/indico_vc_zoom/util.py
+++ b/vc_zoom/indico_vc_zoom/util.py
@@ -203,12 +203,13 @@ def process_alternative_hosts(emails):
             users = [identity.user for identity in Identity.query.filter(criteria)]
     else:
         raise TypeError('invalid mode')
-    return [u.identifier for u in users if u is not None]
+    return [u.persistent_identifier for u in users if u is not None]
 
 
 def get_alt_host_emails(identifiers):
     """Convert a list of identities into a list of enterprise e-mails."""
-    emails = [find_enterprise_email(principal_from_identifier(ident)) for ident in identifiers]
+    emails = [find_enterprise_email(principal_from_identifier(ident, require_user_token=False))
+              for ident in identifiers]
     if None in emails:
         raise VCRoomError(_('Could not find Zoom user for alternative host'))
     return emails

--- a/vc_zoom/pyproject.toml
+++ b/vc_zoom/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'indico-plugin-vc-zoom'
 description = 'Zoom video-conferencing plugin for Indico'
 readme = 'README.md'
-version = '3.3.3'
+version = '3.3.4'
 license = 'MIT'
 authors = [
     { name = 'Indico Team', email = 'indico-team@cern.ch' },
@@ -15,7 +15,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
 ]
 requires-python = '>=3.12.2, <3.13'
-dependencies = ['indico>=3.3.5.dev0']
+dependencies = ['indico>=3.3.7.dev0']
 
 [project.urls]
 GitHub = 'https://github.com/indico/indico-plugins'


### PR DESCRIPTION
In places where the identifiers are stored in a persistent way we now need to use the `persistent_identifier` which is basically the old `identifier` without a signature.

depends on indico/indico#6952