### PR TITLE
Fix bad prometheus/livesync plugin interaction

### DIFF
--- a/livesync/README.md
+++ b/livesync/README.md
@@ -5,6 +5,10 @@ external services, typically to provide advanced search functionality.
 
 ## Changelog
 
+### 3.3.3
+
+- Do not register Celery task unless the plugin is enabled
+
 ### 3.3.2
 
 - Update translations

--- a/livesync/indico_livesync/__init__.py
+++ b/livesync/indico_livesync/__init__.py
@@ -5,7 +5,6 @@
 # them and/or modify them under the terms of the MIT License;
 # see the LICENSE file for more details.
 
-from indico.core import signals
 from indico.util.i18n import make_bound_gettext
 
 
@@ -18,8 +17,3 @@ from .base import LiveSyncBackendBase, LiveSyncPluginBase  # noqa: E402
 from .forms import AgentForm  # noqa: E402
 from .simplify import SimpleChange, process_records  # noqa: E402
 from .uploader import Uploader  # noqa: E402
-
-
-@signals.core.import_tasks.connect
-def _import_tasks(sender, **kwargs):
-    import indico_livesync.task  # noqa: F401

--- a/livesync/indico_livesync/plugin.py
+++ b/livesync/indico_livesync/plugin.py
@@ -60,6 +60,7 @@ class LiveSyncPlugin(IndicoPlugin):
         self.backend_classes = {}
         connect_signals(self)
         self.connect(signals.plugin.cli, self._extend_indico_cli)
+        self.connect(signals.core.import_tasks, self._import_tasks)
         self.template_hook('plugin-details', self._extend_plugin_details)
 
     def get_blueprints(self):
@@ -67,6 +68,9 @@ class LiveSyncPlugin(IndicoPlugin):
 
     def _extend_indico_cli(self, sender, **kwargs):
         return cli
+
+    def _import_tasks(self, sender, **kwargs):
+        import indico_livesync.task  # noqa: F401
 
     def register_backend_class(self, name, backend_class):
         if name in self.backend_classes:

--- a/livesync/pyproject.toml
+++ b/livesync/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'indico-plugin-livesync'
 description = 'Legacy themes for Indico'
 readme = 'README.md'
-version = '3.3.2'
+version = '3.3.3'
 license = 'MIT'
 authors = [{ name = 'Indico Team', email = 'indico-team@cern.ch' }]
 classifiers = [

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -27,6 +27,12 @@ If you're doing development you may want to add this under `scrape_configs`:
 
 ## Changelog
 
+### 3.3.2
+
+- Fix errors if livesync plugin is installed but not enabled and do not expose livesync-related
+  metrics at all in that case
+- Use latest prometheus-client library
+
 ### 3.3.1
 
 - Use latest prometheus-client library

--- a/prometheus/indico_prometheus/plugin.py
+++ b/prometheus/indico_prometheus/plugin.py
@@ -18,6 +18,7 @@ from indico.web.forms.widgets import SwitchWidget
 
 from indico_prometheus import _
 from indico_prometheus.blueprint import blueprint
+from indico_prometheus.metrics import define_metrics
 
 
 class PluginSettingsForm(IndicoForm):
@@ -72,6 +73,10 @@ class PrometheusPlugin(IndicoPlugin):
         'heavy_cache_ttl': TimedeltaConverter,
         'active_user_age': TimedeltaConverter
     }
+
+    def init(self):
+        super().init()
+        define_metrics()
 
     def get_blueprints(self):
         return blueprint

--- a/prometheus/pyproject.toml
+++ b/prometheus/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'indico-plugin-prometheus'
 description = 'Prometheus metrics in Indico servers'
 readme = 'README.md'
-version = '3.3.1'
+version = '3.3.2'
 license = 'MIT'
 authors = [{ name = 'Indico Team', email = 'indico-team@cern.ch' }]
 classifiers = [
@@ -12,7 +12,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
 ]
 requires-python = '>=3.12.2, <3.13'
-dependencies = ['indico>=3.3', 'prometheus-client==0.21.1']
+dependencies = ['indico>=3.3', 'prometheus-client==0.22.1']
 
 [project.urls]
 GitHub = 'https://github.com/indico/indico-plugins'


### PR DESCRIPTION
When using the prometheus plugin but not livesync, the import of the livesync plugin resulted in the task being registered w/ celery, and thus resulted in the task executing and usually failing due to non-existent tables.

Also, the prometheus plugin only checked if the livesync plugin was importable, so even with it disabled it tried to query stats from it, failing in case its tables did not exist.

Now livesync task initialization only happens at plugin init time, and the prometheus plugin also only registers its metrics at init time so the livesync metric is completely skipped if that plugin is disabled.

fixes #268