### PR TITLE
VC/Zoom: Add language interpretation settings

### DIFF
--- a/vc_zoom/README.md
+++ b/vc_zoom/README.md
@@ -11,6 +11,10 @@
 
 ## Changelog
 
+### 3.3.7
+
+- Support Zoom's [Language Interpretation](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0064768) feature
+
 ### 3.3.6
 
 - Compare webhook HMAC token in a more secure manner

--- a/vc_zoom/indico_vc_zoom/fixtures.py
+++ b/vc_zoom/indico_vc_zoom/fixtures.py
@@ -21,6 +21,7 @@ def zoom_plugin(app):
     plugin.settings.set_multi({
         'email_domains': ('megacorp.xyz',),
         'user_lookup_mode': 'email_domains',
+        'allow_language_interpretation': True,
     })
     return plugin
 

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -50,9 +50,14 @@ class VCRoomAttachForm(VCRoomAttachFormBase):
 class VCRoomForm(VCRoomFormBase):
     """Contains all information concerning a Zoom booking."""
 
-    advanced_fields = (['mute_audio', 'mute_host_video', 'mute_participant_video'] +
-                       list(VCRoomFormBase.advanced_fields) +
-                       ['language_interpretation', 'interpreters'])
+    advanced_fields = [
+        'mute_audio',
+        'mute_host_video',
+        'mute_participant_video',
+        *VCRoomFormBase.advanced_fields,
+        'language_interpretation',
+        'interpreters',
+    ]
 
     skip_fields = set(advanced_fields) | VCRoomFormBase.conditional_fields
 
@@ -126,8 +131,18 @@ class VCRoomForm(VCRoomFormBase):
                                       [HiddenUnless('language_interpretation')],
                                       fields=[
                                           {'id': 'email', 'caption': _('Email'), 'type': 'text', 'required': True},
-                                          {'id': 'src_lang', 'caption': _('Source Language'), 'type': 'select', 'required': True},
-                                          {'id': 'target_lang', 'caption': _('Target Language'), 'type': 'select', 'required': True}
+                                          {
+                                              'id': 'src_lang',
+                                              'caption': _('Source Language'),
+                                              'type': 'select',
+                                              'required': True,
+                                          },
+                                          {
+                                              'id': 'target_lang',
+                                              'caption': _('Target Language'),
+                                              'type': 'select',
+                                              'required': True,
+                                          },
                                       ],
                                       choices={
                                           'src_lang': INTERPRETER_LANGUAGE_CHOICES,

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -23,6 +23,7 @@ from indico.web.forms.widgets import SwitchWidget
 from indico_vc_zoom import _
 from indico_vc_zoom.util import find_enterprise_email
 
+
 INTERPRETER_LANGUAGE_CHOICES = {
     'English': _('English'),
     'Chinese': _('Chinese'),

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -24,6 +24,8 @@ from indico_vc_zoom import _
 from indico_vc_zoom.util import find_enterprise_email
 
 
+# Default Zoom-enabled languages for interpretation
+# See: https://developers.zoom.us/docs/api/meetings/#tag/meetings/post/users/{userId}/meetings
 INTERPRETER_LANGUAGE_CHOICES = {
     'English': _('English'),
     'Chinese': _('Chinese'),

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -126,6 +126,10 @@ class VCRoomForm(VCRoomFormBase):
         if not allow_webinars:
             del self.meeting_type
 
+        if not current_plugin.settings.get('allow_language_interpretation'):
+            del self.language_interpretation
+            del self.interpreters
+
     language_interpretation = BooleanField(_('Language interpretation'),
                                            widget=SwitchWidget(),
                                            description=_('Enable interpretation for this meeting'))

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -108,6 +108,33 @@ class VCRoomForm(VCRoomFormBase):
 
     description = TextAreaField(_('Description'), description=_('Optional description for this meeting'))
 
+    language_interpretation = BooleanField(_('Language interpretation'), widget=SwitchWidget(),
+                                           description=_('Enable interpretation for this meeting'))
+
+    interpreters = MultipleItemsField(
+        _('Interpreters'),
+        [HiddenUnless('language_interpretation')],
+        fields=[
+            {'id': 'email', 'caption': _('Email'), 'type': 'text', 'required': True},
+            {
+                'id': 'src_lang',
+                'caption': _('Source Language'),
+                'type': 'select',
+                'required': True,
+            },
+            {
+                'id': 'target_lang',
+                'caption': _('Target Language'),
+                'type': 'select',
+                'required': True,
+            },
+        ],
+        choices={
+            'src_lang': INTERPRETER_LANGUAGE_CHOICES,
+            'target_lang': INTERPRETER_LANGUAGE_CHOICES,
+        },
+    )
+
     def __init__(self, *args, **kwargs):
         defaults = kwargs['obj']
         if defaults.host_user is None and defaults.host is not None:
@@ -129,33 +156,6 @@ class VCRoomForm(VCRoomFormBase):
         if not current_plugin.settings.get('allow_language_interpretation'):
             del self.language_interpretation
             del self.interpreters
-
-    language_interpretation = BooleanField(_('Language interpretation'),
-                                           widget=SwitchWidget(),
-                                           description=_('Enable interpretation for this meeting'))
-
-    interpreters = MultipleItemsField(_('Interpreters'),
-                                      [HiddenUnless('language_interpretation')],
-                                      fields=[
-                                          {'id': 'email', 'caption': _('Email'), 'type': 'text', 'required': True},
-                                          {
-                                              'id': 'src_lang',
-                                              'caption': _('Source Language'),
-                                              'type': 'select',
-                                              'required': True,
-                                          },
-                                          {
-                                              'id': 'target_lang',
-                                              'caption': _('Target Language'),
-                                              'type': 'select',
-                                              'required': True,
-                                          },
-                                      ],
-                                      choices={
-                                          'src_lang': INTERPRETER_LANGUAGE_CHOICES,
-                                          'target_lang': INTERPRETER_LANGUAGE_CHOICES,
-                                      },
-                                      description=_('The email address and the two languages for each interpreter.'))
 
     def validate_host_choice(self, field):
         if field.data == 'myself':

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -420,11 +420,11 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         zoom_language_interpretation = zoom_meeting_settings.get('language_interpretation', {})
         zoom_interpreters = [
             {
-                'email': i['email'],
-                'src_lang': i['interpreter_languages'].split(',')[0],
-                'target_lang': i['interpreter_languages'].split(',')[1],
+                'email': x['email'],
+                'src_lang': x['interpreter_languages'].split(',')[0],
+                'target_lang': x['interpreter_languages'].split(',')[1],
             }
-            for i in zoom_language_interpretation.get('interpreters', [])
+            for x in zoom_language_interpretation.get('interpreters', [])
         ]
         local_interpreters = vc_room.data.get('interpreters') or []
         interpretation_changed = (

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -414,12 +414,22 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         if vc_room.data['mute_host_video'] == zoom_meeting_settings['host_video']:
             changes.setdefault('settings', {})['host_video'] = not vc_room.data['mute_host_video']
 
-        if (vc_room.data.get('language_interpretation', False) != zoom_meeting_settings.get('language_interpretation', {}).get('enable', False) or
-                (vc_room.data.get('interpreters') or []) != [
-                    {'email': i['email'], 'src_lang': i['interpreter_languages'].split(',')[0],
-                     'target_lang': i['interpreter_languages'].split(',')[1]}
-                    for i in zoom_meeting_settings.get('language_interpretation', {}).get('interpreters', [])
-                ]):
+        zoom_language_interpretation = zoom_meeting_settings.get('language_interpretation', {})
+        zoom_interpreters = [
+            {
+                'email': i['email'],
+                'src_lang': i['interpreter_languages'].split(',')[0],
+                'target_lang': i['interpreter_languages'].split(',')[1],
+            }
+            for i in zoom_language_interpretation.get('interpreters', [])
+        ]
+        local_interpreters = vc_room.data.get('interpreters') or []
+        interpretation_changed = (
+            vc_room.data.get('language_interpretation', False)
+            != zoom_language_interpretation.get('enable', False)
+        )
+        interpreters_changed = local_interpreters != zoom_interpreters
+        if interpretation_changed or interpreters_changed:
             changes.setdefault('settings', {})['language_interpretation'] = {
                 'enable': vc_room.data.get('language_interpretation', False),
                 'interpreters': [

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -46,7 +46,7 @@ class PluginSettingsForm(VCPluginSettingsFormBase):
     _fieldsets = [
         (_('API Credentials'), ['account_id', 'client_id', 'client_secret', 'webhook_token']),
         (_('Zoom Account'), ['user_lookup_mode', 'email_domains', 'authenticators', 'enterprise_domain',
-                             'allow_webinars', 'phone_link']),
+                             'allow_webinars', 'allow_language_interpretation', 'phone_link']),
         (_('Room Settings'), ['mute_audio', 'mute_host_video', 'mute_participant_video', 'join_before_host',
                               'waiting_room']),
         (_('Notifications'), ['creation_email_footer', 'send_host_url', 'notification_emails']),
@@ -85,6 +85,11 @@ class PluginSettingsForm(VCPluginSettingsFormBase):
     allow_webinars = BooleanField(_('Allow Webinars (Experimental)'),
                                   widget=SwitchWidget(),
                                   description=_('Allow webinars to be created through Indico. Use at your own risk.'))
+
+    allow_language_interpretation = BooleanField(_('Allow Language Interpretation'),
+                                                 widget=SwitchWidget(),
+                                                 description=_('Allow enabling language interpretation for meetings '
+                                                               'and webinars.'))
 
     mute_audio = BooleanField(_('Mute audio'),
                               widget=SwitchWidget(),
@@ -162,6 +167,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         'authenticators': [],
         'enterprise_domain': '',
         'allow_webinars': False,
+        'allow_language_interpretation': False,
         'mute_host_video': True,
         'mute_audio': True,
         'mute_participant_video': True,

--- a/vc_zoom/pyproject.toml
+++ b/vc_zoom/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'indico-plugin-vc-zoom'
 description = 'Zoom video-conferencing plugin for Indico'
 readme = 'README.md'
-version = '3.3.6'
+version = '3.3.7'
 license = 'MIT'
 authors = [
     { name = 'Indico Team', email = 'indico-team@cern.ch' },

--- a/vc_zoom/tests/interpretation_test.py
+++ b/vc_zoom/tests/interpretation_test.py
@@ -5,10 +5,12 @@
 # them and/or modify them under the terms of the MIT License;
 # see the LICENSE file for more details.
 
+import json
 from datetime import datetime
 from zoneinfo import ZoneInfo
-import json
+
 from indico_vc_zoom.fixtures import JSON_DATA
+
 
 TZ = ZoneInfo('Europe/Zurich')
 
@@ -83,8 +85,9 @@ def test_interpretation_split_join(db, test_client, zoom_api, create_event, smtp
         }
     }, False))
 
-    from indico_vc_zoom.plugin import ZoomPlugin
     from indico.core.plugins import plugin_engine
+
+    from indico_vc_zoom.plugin import ZoomPlugin
     plugin = ZoomPlugin(plugin_engine, app)
     plugin.refresh_room(vc_room, event)
 

--- a/vc_zoom/tests/interpretation_test.py
+++ b/vc_zoom/tests/interpretation_test.py
@@ -12,6 +12,7 @@ from indico_vc_zoom.fixtures import JSON_DATA
 
 TZ = ZoneInfo('Europe/Zurich')
 
+
 def test_interpretation_split_join(db, test_client, zoom_api, create_event, smtp, app, mocker):
     event = create_event(
         creator=zoom_api['user'],
@@ -54,8 +55,7 @@ def test_interpretation_split_join(db, test_client, zoom_api, create_event, smtp
 
     # Check what was sent to Zoom API
     assert zoom_api['create_meeting'].called
-    args, kwargs = zoom_api['create_meeting'].call_args
-    sent_settings = kwargs['settings']
+    sent_settings = zoom_api['create_meeting'].call_args.kwargs['settings']
     assert sent_settings['language_interpretation']['enable'] is True
     assert sent_settings['language_interpretation']['interpreters'] == [
         {'email': i['email'], 'interpreter_languages': f"{i['src_lang']},{i['target_lang']}"}

--- a/vc_zoom/tests/interpretation_test.py
+++ b/vc_zoom/tests/interpretation_test.py
@@ -1,0 +1,93 @@
+# This file is part of the Indico plugins.
+# Copyright (C) 2020 - 2026 CERN and ENEA
+#
+# The Indico plugins are free software; you can redistribute
+# them and/or modify them under the terms of the MIT License;
+# see the LICENSE file for more details.
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+import json
+from indico_vc_zoom.fixtures import JSON_DATA
+
+TZ = ZoneInfo('Europe/Zurich')
+
+def test_interpretation_split_join(db, test_client, zoom_api, create_event, smtp, app, mocker):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event Interpretation',
+        creator_has_privileges=True,
+    )
+
+    with test_client.session_transaction() as sess:
+        sess.set_session_user(zoom_api['user'])
+        sess['_csrf_token'] = 'supersecure'
+
+    interpreters = [
+        {'email': 'int1@example.com', 'src_lang': 'English', 'target_lang': 'French'},
+        {'email': 'int2@example.com', 'src_lang': 'German', 'target_lang': 'Spanish'},
+        {'email': 'int3@example.com', 'src_lang': 'English', 'target_lang': 'Korean'},
+        {'email': 'int4@example.com', 'src_lang': 'Japanese', 'target_lang': 'Chinese'},
+        {'email': 'int5@example.com', 'src_lang': 'Portuguese', 'target_lang': 'Russian'}
+    ]
+
+    resp = test_client.post(
+        f'/event/{event.id}/manage/videoconference/zoom/create',
+        data={
+            'vc-csrf_token': 'supersecure',
+            'vc-name': 'Interpretation Meeting',
+            'vc-linking': 'event',
+            'vc-host_choice': 'myself',
+            'vc-password': '12345678',
+            'vc-password_visibility': 'logged_in',
+            'vc-description': 'Testing interpretation',
+            'vc-show': 'y',
+            'vc-language_interpretation': 'y',
+            'vc-interpreters': json.dumps(interpreters),
+            'vc-event': event.id,
+        },
+    )
+    assert resp.status_code == 200
+    assert b'data-error' not in resp.data
+
+    # Check what was sent to Zoom API
+    assert zoom_api['create_meeting'].called
+    args, kwargs = zoom_api['create_meeting'].call_args
+    sent_settings = kwargs['settings']
+    assert sent_settings['language_interpretation']['enable'] is True
+    assert sent_settings['language_interpretation']['interpreters'] == [
+        {'email': i['email'], 'interpreter_languages': f"{i['src_lang']},{i['target_lang']}"}
+        for i in interpreters
+    ]
+
+    vc_room = event.vc_room_associations[0].vc_room
+    assert vc_room.data['language_interpretation'] is True
+    assert len(vc_room.data['interpreters']) == 5
+    assert vc_room.data['interpreters'] == interpreters
+
+    # Test Refreshing from Zoom
+    # Mock zoom response for refresh
+    mocker.patch('indico_vc_zoom.plugin.fetch_zoom_meeting', return_value=({
+        **JSON_DATA,
+        'id': vc_room.data['zoom_id'],
+        'settings': {
+            **JSON_DATA['settings'],
+            'language_interpretation': {
+                'enable': True,
+                'interpreters': [
+                    {'email': 'int3@example.com', 'interpreter_languages': 'German,Korean'}
+                ]
+            }
+        }
+    }, False))
+
+    from indico_vc_zoom.plugin import ZoomPlugin
+    from indico.core.plugins import plugin_engine
+    plugin = ZoomPlugin(plugin_engine, app)
+    plugin.refresh_room(vc_room, event)
+
+    assert vc_room.data['interpreters'] == [
+        {'email': 'int3@example.com', 'src_lang': 'German', 'target_lang': 'Korean'}
+    ]


### PR DESCRIPTION
This PR adds the language interpretation feature to the zoom plugin.

### Screenshots

<img width="935" height="961" alt="Screenshot 2026-01-25 at 16 20 22" src="https://github.com/user-attachments/assets/9519b4a6-f707-4984-9e59-d5d43d025f4c" />
<img width="1166" height="769" alt="Screenshot 2026-01-25 at 16 44 08" src="https://github.com/user-attachments/assets/141fe4ea-520c-422f-aa6e-ceb7d464d2bc" />
<img width="1032" height="819" alt="Screenshot 2026-01-25 at 16 52 08" src="https://github.com/user-attachments/assets/b74b97cb-1bf2-4c86-8d3e-441b0a8e9c43" />


Also changes get reflected in zoom (when editing through zoom management too!).

<img width="1065" height="688" alt="Screenshot 2026-01-25 at 16 46 02" src="https://github.com/user-attachments/assets/e1826e49-45c6-4301-bfcf-050872011c56" />
