### PR TITLE
Auto check-in registrations via participant_joined webhook

### DIFF
--- a/vc_zoom/README.md
+++ b/vc_zoom/README.md
@@ -19,6 +19,8 @@
 - Never use a PMI meeting ID when creating a new meeting
 - Add automatic Zoom registration: event managers can opt-in to automatically register/unregister
   Indico participants in the corresponding Zoom meeting or webinar
+- Automatically check in Indico registrations when a participant joins the corresponding Zoom
+  meeting or webinar (requires automatic registration to be enabled on the room)
 
 ### 3.3.5
 

--- a/vc_zoom/README.md
+++ b/vc_zoom/README.md
@@ -20,7 +20,7 @@
 - Add automatic Zoom registration: event managers can opt-in to automatically register/unregister
   Indico participants in the corresponding Zoom meeting or webinar
 - Automatically check in Indico registrations when a participant joins the corresponding Zoom
-  meeting or webinar (requires automatic registration to be enabled on the room)
+  meeting or webinar (opt-in per room, requires automatic registration to be enabled on the room)
 
 ### 3.3.5
 
@@ -168,6 +168,8 @@ Select the following "Event types":
  * `Meeting has been deleted`
  * `Webinar has been updated`
  * `Webinar has been deleted`
+ * `Meeting participant joined` (optional, only needed for automatic check-in)
+ * `Webinar participant joined` (optional, only needed for automatic check-in)
 
 
 ## Plugin Configuration

--- a/vc_zoom/indico_vc_zoom/controllers.py
+++ b/vc_zoom/indico_vc_zoom/controllers.py
@@ -16,6 +16,7 @@ from webargs import fields
 from webargs.flaskparser import use_kwargs
 from werkzeug.exceptions import Forbidden, ServiceUnavailable
 
+from indico.core import signals
 from indico.core.db import db
 from indico.core.errors import UserValueError
 from indico.modules.vc.controllers import RHVCSystemEventBase
@@ -98,5 +99,22 @@ class RHWebhook(RH):
         elif event in ('meeting.deleted', 'webinar.deleted'):
             current_plugin.logger.info('Zoom meeting deleted: %s', meeting_id)
             vc_room.status = VCRoomStatus.deleted
+        elif event in ('meeting.participant_joined', 'webinar.participant_joined'):
+            if not vc_room.data.get('auto_register'):
+                return
+            email = payload['object'].get('participant', {}).get('email', '')
+            if not email:
+                current_plugin.logger.debug('participant_joined with no email for meeting %s', meeting_id)
+                return
+            registration = current_plugin._find_registration_by_participant_email(vc_room, email)
+            if registration is None:
+                current_plugin.logger.debug('No Indico registration for email %s in meeting %s', email, meeting_id)
+                return
+            if registration.checked_in:
+                return
+            registration.checked_in = True
+            signals.event.registration_checkin_updated.send(registration)
+            current_plugin.logger.info('Checked in registration %s via Zoom webhook (meeting %s)',
+                                       registration.id, meeting_id)
         else:
             current_plugin.logger.warning('Unhandled Zoom webhook payload: %s', event)

--- a/vc_zoom/indico_vc_zoom/controllers.py
+++ b/vc_zoom/indico_vc_zoom/controllers.py
@@ -100,7 +100,7 @@ class RHWebhook(RH):
             current_plugin.logger.info('Zoom meeting deleted: %s', meeting_id)
             vc_room.status = VCRoomStatus.deleted
         elif event in ('meeting.participant_joined', 'webinar.participant_joined'):
-            if not vc_room.data.get('auto_register') or not vc_room.data.get('webhook_checkin'):
+            if not vc_room.data.get('auto_register') or not vc_room.data.get('auto_checkin'):
                 return
             email = payload['object'].get('participant', {}).get('email', '')
             if not email:

--- a/vc_zoom/indico_vc_zoom/controllers.py
+++ b/vc_zoom/indico_vc_zoom/controllers.py
@@ -100,7 +100,7 @@ class RHWebhook(RH):
             current_plugin.logger.info('Zoom meeting deleted: %s', meeting_id)
             vc_room.status = VCRoomStatus.deleted
         elif event in ('meeting.participant_joined', 'webinar.participant_joined'):
-            if not vc_room.data.get('auto_register'):
+            if not vc_room.data.get('auto_register') or not vc_room.data.get('webhook_checkin'):
                 return
             email = payload['object'].get('participant', {}).get('email', '')
             if not email:

--- a/vc_zoom/indico_vc_zoom/controllers.py
+++ b/vc_zoom/indico_vc_zoom/controllers.py
@@ -86,7 +86,8 @@ class RHWebhook(RH):
         })
 
     def _handle_zoom_event(self, event, payload):
-        meeting_id = payload['object']['id']
+        # XXX Some Zoom events receive the ID as a string, others as a number
+        meeting_id = int(payload['object']['id'])
         vc_room = VCRoom.query.filter(VCRoom.data.contains({'zoom_id': meeting_id})).first()
 
         if not vc_room:

--- a/vc_zoom/indico_vc_zoom/fixtures.py
+++ b/vc_zoom/indico_vc_zoom/fixtures.py
@@ -14,7 +14,9 @@ import pytest
 from indico.core.plugins import plugin_engine
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.items import RegistrationFormItemType, RegistrationFormSection
-from indico.modules.events.registration.util import create_personal_data_fields
+from indico.modules.events.registration.models.registrations import RegistrationState
+from indico.modules.events.registration.util import create_personal_data_fields, create_registration
+from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation, VCRoomStatus
 
 
 TZ = ZoneInfo('Europe/Zurich')
@@ -161,6 +163,47 @@ def zoom_api(zoom_plugin, create_user, mocker):
         'api_delete_meeting': api_delete_meeting,
         'get_user': api_get_user,
     }
+
+
+@pytest.fixture
+def create_vc_room_with_assoc(db):
+    """Create a Zoom VCRoom + association for an event without going through the HTTP endpoint."""
+    def _create(event, zoom_user, *, auto_register=True, auto_checkin=False):
+        vc_room = VCRoom(name='Test Meeting', type='zoom', status=VCRoomStatus.created, created_by_user=zoom_user)
+        vc_room.data = {
+            'zoom_id': 'zmeeting_manual',
+            'meeting_type': 'regular',
+            'host': 'User:1',
+            'auto_register': auto_register,
+            'auto_checkin': auto_checkin,
+        }
+        assoc = VCRoomEventAssociation(link_object=event, vc_room=vc_room, show=True,
+                                       data={'password_visibility': 'everyone'})
+        db.session.add(vc_room)
+        db.session.add(assoc)
+        db.session.flush()
+        return vc_room, assoc
+    return _create
+
+
+@pytest.fixture
+def make_complete_registration(db, zoom_plugin):
+    """Create a completed registration while auto_register is off to avoid triggering sync."""
+    def _make(reg_form, email, first_name, last_name):
+        data = {'email': email, 'first_name': first_name, 'last_name': last_name, 'affiliation': 'MegaCorp'}
+        form_data = {(getattr(f, 'html_field_name', None) or f.personal_data_type.name): data[f.personal_data_type.name]
+                     for f in reg_form.active_fields if f.personal_data_type and f.personal_data_type.name in data}
+        form_data['email'] = email
+
+        prev = zoom_plugin.settings.get('allow_auto_register')
+        zoom_plugin.settings.set('allow_auto_register', False)
+        registration = create_registration(reg_form, form_data)
+        db.session.flush()
+        registration.state = RegistrationState.complete
+        db.session.flush()
+        zoom_plugin.settings.set('allow_auto_register', prev)
+        return registration
+    return _make
 
 
 @pytest.fixture

--- a/vc_zoom/indico_vc_zoom/fixtures.py
+++ b/vc_zoom/indico_vc_zoom/fixtures.py
@@ -6,10 +6,18 @@
 # see the LICENSE file for more details.
 
 import itertools
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import pytest
 
 from indico.core.plugins import plugin_engine
+from indico.modules.events.registration.models.forms import RegistrationForm
+from indico.modules.events.registration.models.items import RegistrationFormItemType, RegistrationFormSection
+from indico.modules.events.registration.util import create_personal_data_fields
+
+
+TZ = ZoneInfo('Europe/Zurich')
 
 
 @pytest.fixture
@@ -24,6 +32,27 @@ def zoom_plugin(app):
         'allow_language_interpretation': True,
     })
     return plugin
+
+
+@pytest.fixture
+def zoom_user(zoom_api):
+    return zoom_api['user']
+
+
+@pytest.fixture
+def reg_form(create_event, db):
+    event = create_event(
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+    )
+    regform = RegistrationForm(event=event, title='Test Form', currency='EUR')
+    section = RegistrationFormSection(registration_form=regform, title='Personal Data',
+                                      type=RegistrationFormItemType.section_pd)
+    regform.sections.append(section)
+    create_personal_data_fields(regform)
+    event.registration_forms.append(regform)
+    db.session.flush()
+    return regform
 
 
 @pytest.fixture
@@ -132,3 +161,28 @@ def zoom_api(zoom_plugin, create_user, mocker):
         'api_delete_meeting': api_delete_meeting,
         'get_user': api_get_user,
     }
+
+
+@pytest.fixture
+def zoom_api_registrants(zoom_api, mocker):
+    zoom_api['add_meeting_registrant'] = mocker.patch('indico_vc_zoom.plugin.ZoomIndicoClient.add_meeting_registrant')
+    zoom_api['add_webinar_registrant'] = mocker.patch('indico_vc_zoom.plugin.ZoomIndicoClient.add_webinar_registrant')
+    zoom_api['update_meeting_registrants_status'] = mocker.patch(
+        'indico_vc_zoom.plugin.ZoomIndicoClient.update_meeting_registrants_status')
+    zoom_api['update_webinar_registrants_status'] = mocker.patch(
+        'indico_vc_zoom.plugin.ZoomIndicoClient.update_webinar_registrants_status')
+    zoom_api['list_meeting_registrants'] = mocker.patch(
+        'indico_vc_zoom.plugin.ZoomIndicoClient.list_meeting_registrants')
+    zoom_api['list_webinar_registrants'] = mocker.patch(
+        'indico_vc_zoom.plugin.ZoomIndicoClient.list_webinar_registrants')
+    zoom_api['batch_meeting_registrants'] = mocker.patch(
+        'indico_vc_zoom.plugin.ZoomIndicoClient.batch_meeting_registrants')
+    zoom_api['batch_webinar_registrants'] = mocker.patch(
+        'indico_vc_zoom.plugin.ZoomIndicoClient.batch_webinar_registrants')
+
+    zoom_api['add_meeting_registrant'].return_value = {}
+    zoom_api['add_webinar_registrant'].return_value = {}
+    zoom_api['list_meeting_registrants'].return_value = {'registrants': [{'id': 'reg123', 'email': 'test@example.com'}]}
+    zoom_api['list_webinar_registrants'].return_value = {'registrants': [{'id': 'reg123', 'email': 'test@example.com'}]}
+
+    return zoom_api

--- a/vc_zoom/indico_vc_zoom/fixtures.py
+++ b/vc_zoom/indico_vc_zoom/fixtures.py
@@ -126,7 +126,7 @@ JSON_DATA = {
 @pytest.fixture
 def zoom_api(zoom_plugin, create_user, mocker):
     """Mock some Zoom API endpoints."""
-    meeting_ids = iter(f'zmeeting{n}' for n in itertools.count(start=1, step=1))
+    meeting_ids = itertools.count(start=100000, step=1)
 
     def _create_meeting(*args, **kwargs):
         return {**JSON_DATA, 'id': next(meeting_ids)}
@@ -171,7 +171,7 @@ def create_vc_room_with_assoc(db):
     def _create(event, zoom_user, *, auto_register=True, auto_checkin=False):
         vc_room = VCRoom(name='Test Meeting', type='zoom', status=VCRoomStatus.created, created_by_user=zoom_user)
         vc_room.data = {
-            'zoom_id': 'zmeeting_manual',
+            'zoom_id': 26262600,
             'meeting_type': 'regular',
             'host': 'User:1',
             'auto_register': auto_register,

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -115,7 +115,7 @@ class VCRoomForm(VCRoomFormBase):
                                                'to "No one" so participants only receive their '
                                                'personalized join link'))
 
-    webhook_checkin = BooleanField(_('Automatic check-in'),
+    auto_checkin = BooleanField(_('Automatic check-in'),
                                    [HiddenUnless('auto_register')],
                                    widget=SwitchWidget(),
                                    description=_('Automatically check in registrants when they join this '
@@ -170,7 +170,7 @@ class VCRoomForm(VCRoomFormBase):
 
         if not current_plugin.settings.get('allow_auto_register'):
             del self.auto_register
-            del self.webhook_checkin
+            del self.auto_checkin
 
         self._auto_register_locked = False
         if getattr(self, 'auto_register', None) is not None and self._is_link_target_in_past():

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -113,7 +113,13 @@ class VCRoomForm(VCRoomFormBase):
                                  description=_('Automatically register Indico registrants in this Zoom '
                                                'meeting/webinar. Consider setting "Passcode visibility" '
                                                'to "No one" so participants only receive their '
-                                               'personalized join link.'))
+                                               'personalized join link'))
+
+    webhook_checkin = BooleanField(_('Automatic check-in'),
+                                   [HiddenUnless('auto_register')],
+                                   widget=SwitchWidget(),
+                                   description=_('Automatically check in registrants when they join this '
+                                                 'Zoom meeting/webinar'))
 
     description = TextAreaField(_('Description'), description=_('Optional description for this meeting'))
 
@@ -164,6 +170,7 @@ class VCRoomForm(VCRoomFormBase):
 
         if not current_plugin.settings.get('allow_auto_register'):
             del self.auto_register
+            del self.webhook_checkin
 
         self._auto_register_locked = False
         if getattr(self, 'auto_register', None) is not None and self._is_link_target_in_past():

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -424,7 +424,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
     def update_data_vc_room(self, vc_room, data, is_new=False):
         auto_register_before = vc_room.data.get('auto_register') if not is_new else None
         super().update_data_vc_room(vc_room, data, is_new=is_new)
-        fields = {'description', 'password', 'auto_register', 'webhook_checkin'}
+        fields = {'description', 'password', 'auto_register', 'auto_checkin'}
 
         # we may end up not getting a meeting_type from the form
         # (i.e. webinars are disabled)

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -1063,6 +1063,19 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                 self.logger.info(f'Batch-added registrants to Zoom {zoom_type} %s: %s',  # noqa: G004
                                  zoom_id, emails)
 
+    def _find_registration_by_participant_email(self, vc_room, email):
+        event_ids = {assoc.event_id for assoc in vc_room.events}
+        if not event_ids:
+            return None
+        candidates = (Registration.query
+                      .join(Registration.registration_form)
+                      .filter(RegistrationForm.event_id.in_(event_ids),
+                              Registration.state.in_([RegistrationState.complete, RegistrationState.unpaid]),
+                              ~Registration.is_deleted,
+                              ~RegistrationForm.is_deleted))
+        email_lower = email.lower()
+        return next((c for c in candidates if self._get_registrant_email(c).lower() == email_lower), None)
+
     def _remove_registrants(self, client, zoom_id, vc_room, email_ids, is_webinar):
         if not email_ids:
             return

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -424,7 +424,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
     def update_data_vc_room(self, vc_room, data, is_new=False):
         auto_register_before = vc_room.data.get('auto_register') if not is_new else None
         super().update_data_vc_room(vc_room, data, is_new=is_new)
-        fields = {'description', 'password', 'auto_register'}
+        fields = {'description', 'password', 'auto_register', 'webhook_checkin'}
 
         # we may end up not getting a meeting_type from the form
         # (i.e. webinars are disabled)

--- a/vc_zoom/tests/operation_test.py
+++ b/vc_zoom/tests/operation_test.py
@@ -117,6 +117,7 @@ def test_password_change(create_user, mocker, create_event, create_zoom_meeting,
     assert vc_room.data['url'] == 'https://example.com/llamas'
 
 
+@pytest.mark.usefixtures('auto_register_before')
 @pytest.mark.parametrize('meeting_type', ('regular', 'webinar'))
 @pytest.mark.parametrize(('auto_register_before', 'auto_register_after', 'current_approval_type', 'expected'), (
     (False, True, 2, {'settings': {'approval_type': 0}}),
@@ -126,7 +127,7 @@ def test_password_change(create_user, mocker, create_event, create_zoom_meeting,
 ))
 def test_update_room_pushes_approval_type(
     mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api,
-    auto_register_before, auto_register_after, current_approval_type, expected, meeting_type,
+    auto_register_after, current_approval_type, expected, meeting_type,
 ):
     event = create_event(
         creator=zoom_api['user'],

--- a/vc_zoom/tests/operation_test.py
+++ b/vc_zoom/tests/operation_test.py
@@ -109,7 +109,7 @@ def test_password_change(create_user, mocker, create_event, create_zoom_meeting,
 
     zoom_plugin.update_room(vc_room, vc_room.events[0].event)
 
-    zoom_api['update_meeting'].assert_called_with('zmeeting1', {
+    zoom_api['update_meeting'].assert_called_with(100000, {
         'password': '12341234',
     })
 
@@ -143,7 +143,7 @@ def test_update_room_pushes_approval_type(
     is_webinar = meeting_type == 'webinar'
     mocker.patch(
         'indico_vc_zoom.plugin.fetch_zoom_meeting',
-        return_value=(_aligned_meeting('zmeeting1', approval_type=current_approval_type), is_webinar),
+        return_value=(_aligned_meeting(100000, approval_type=current_approval_type), is_webinar),
     )
 
     api_mock = zoom_api['update_webinar' if is_webinar else 'update_meeting']
@@ -157,7 +157,7 @@ def test_update_room_pushes_approval_type(
     if expected is None:
         api_mock.assert_not_called()
     else:
-        api_mock.assert_called_with('zmeeting1', expected)
+        api_mock.assert_called_with(100000, expected)
 
 
 @pytest.mark.parametrize('meeting_type', ('regular', 'webinar'))
@@ -184,7 +184,7 @@ def test_update_data_vc_room_pushes_approval_type_before_sync(
     is_webinar = meeting_type == 'webinar'
     mocker.patch(
         'indico_vc_zoom.plugin.fetch_zoom_meeting',
-        return_value=(_aligned_meeting('zmeeting1', approval_type=expected_approval_type), is_webinar),
+        return_value=(_aligned_meeting(100000, approval_type=expected_approval_type), is_webinar),
     )
     api_mock = zoom_api['update_webinar' if is_webinar else 'update_meeting']
     other_mock = zoom_api['update_meeting' if is_webinar else 'update_webinar']
@@ -193,7 +193,7 @@ def test_update_data_vc_room_pushes_approval_type_before_sync(
 
     zoom_plugin.update_data_vc_room(vc_room, {'auto_register': auto_register_after})
 
-    api_mock.assert_called_once_with('zmeeting1', {'settings': {'approval_type': expected_approval_type}})
+    api_mock.assert_called_once_with(100000, {'settings': {'approval_type': expected_approval_type}})
     other_mock.assert_not_called()
 
 
@@ -235,7 +235,7 @@ def test_push_approval_type_warns_when_zoom_drops_patch(
     # Zoom accepts the PATCH (no error) but the read-back shows the value was not honored
     mocker.patch(
         'indico_vc_zoom.plugin.fetch_zoom_meeting',
-        return_value=(_aligned_meeting('zmeeting1', approval_type=2), is_webinar),
+        return_value=(_aligned_meeting(100000, approval_type=2), is_webinar),
     )
     warning_mock = mocker.patch.object(zoom_plugin.logger, 'warning')
 
@@ -263,7 +263,7 @@ def test_update_room_warns_when_zoom_drops_approval_type_patch(
     # Both the pre- and post-PATCH fetches return approval_type=2 (Zoom dropped the change)
     mocker.patch(
         'indico_vc_zoom.plugin.fetch_zoom_meeting',
-        return_value=(_aligned_meeting('zmeeting1', approval_type=2), False),
+        return_value=(_aligned_meeting(100000, approval_type=2), False),
     )
     warning_mock = mocker.patch.object(zoom_plugin.logger, 'warning')
 

--- a/vc_zoom/tests/registration_test.py
+++ b/vc_zoom/tests/registration_test.py
@@ -271,7 +271,7 @@ def test_registration_form_deleted_batches_removals(db, zoom_plugin, zoom_api_re
     assert cancelled_emails == {'alice@example.com', 'bob@example.com'}
 
 
-def _create_vc_room_with_assoc(db, event, zoom_user, *, auto_register=True, webhook_checkin=False):
+def _create_vc_room_with_assoc(db, event, zoom_user, *, auto_register=True, auto_checkin=False):
     """Create a Zoom VCRoom + association for an event without going through the HTTP endpoint."""
     vc_room = VCRoom(name='Test Meeting', type='zoom', status=VCRoomStatus.created, created_by_user=zoom_user)
     vc_room.data = {
@@ -279,7 +279,7 @@ def _create_vc_room_with_assoc(db, event, zoom_user, *, auto_register=True, webh
         'meeting_type': 'regular',
         'host': 'User:1',
         'auto_register': auto_register,
-        'webhook_checkin': webhook_checkin,
+        'auto_checkin': auto_checkin,
     }
     assoc = VCRoomEventAssociation(link_object=event, vc_room=vc_room, show=True,
                                    data={'password_visibility': 'everyone'})

--- a/vc_zoom/tests/registration_test.py
+++ b/vc_zoom/tests/registration_test.py
@@ -271,7 +271,7 @@ def test_registration_form_deleted_batches_removals(db, zoom_plugin, zoom_api_re
     assert cancelled_emails == {'alice@example.com', 'bob@example.com'}
 
 
-def _create_vc_room_with_assoc(db, event, zoom_user, *, auto_register=True):
+def _create_vc_room_with_assoc(db, event, zoom_user, *, auto_register=True, webhook_checkin=False):
     """Create a Zoom VCRoom + association for an event without going through the HTTP endpoint."""
     vc_room = VCRoom(name='Test Meeting', type='zoom', status=VCRoomStatus.created, created_by_user=zoom_user)
     vc_room.data = {
@@ -279,6 +279,7 @@ def _create_vc_room_with_assoc(db, event, zoom_user, *, auto_register=True):
         'meeting_type': 'regular',
         'host': 'User:1',
         'auto_register': auto_register,
+        'webhook_checkin': webhook_checkin,
     }
     assoc = VCRoomEventAssociation(link_object=event, vc_room=vc_room, show=True,
                                    data={'password_visibility': 'everyone'})

--- a/vc_zoom/tests/registration_test.py
+++ b/vc_zoom/tests/registration_test.py
@@ -5,8 +5,7 @@
 # them and/or modify them under the terms of the MIT License;
 # see the LICENSE file for more details.
 
-from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
+from datetime import timedelta
 
 import pytest
 from flask import session
@@ -19,55 +18,6 @@ from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import RegistrationState
 from indico.modules.events.registration.util import create_personal_data_fields, create_registration
 from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation, VCRoomStatus
-
-
-TZ = ZoneInfo('Europe/Zurich')
-
-
-@pytest.fixture
-def zoom_user(create_user):
-    return create_user(1, email='don.orange@megacorp.xyz')
-
-
-@pytest.fixture
-def reg_form(create_event, db):
-    event = create_event(
-        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
-        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
-    )
-    regform = RegistrationForm(event=event, title='Test Form', currency='EUR')
-    # Add personal data section
-    section = RegistrationFormSection(registration_form=regform, title='Personal Data',
-                                      type=RegistrationFormItemType.section_pd)
-    regform.sections.append(section)
-    create_personal_data_fields(regform)
-    event.registration_forms.append(regform)
-    db.session.flush()
-    return regform
-
-
-@pytest.fixture
-def zoom_api_registrants(zoom_api, mocker):
-    zoom_api['add_meeting_registrant'] = mocker.patch('indico_vc_zoom.plugin.ZoomIndicoClient.add_meeting_registrant')
-    zoom_api['add_webinar_registrant'] = mocker.patch('indico_vc_zoom.plugin.ZoomIndicoClient.add_webinar_registrant')
-    zoom_api['update_meeting_registrants_status'] = mocker.patch(
-        'indico_vc_zoom.plugin.ZoomIndicoClient.update_meeting_registrants_status')
-    zoom_api['update_webinar_registrants_status'] = mocker.patch(
-        'indico_vc_zoom.plugin.ZoomIndicoClient.update_webinar_registrants_status')
-    zoom_api['list_meeting_registrants'] = mocker.patch(
-        'indico_vc_zoom.plugin.ZoomIndicoClient.list_meeting_registrants')
-    zoom_api['list_webinar_registrants'] = mocker.patch(
-        'indico_vc_zoom.plugin.ZoomIndicoClient.list_webinar_registrants')
-
-    zoom_api['batch_meeting_registrants'] = mocker.patch(
-        'indico_vc_zoom.plugin.ZoomIndicoClient.batch_meeting_registrants')
-    zoom_api['batch_webinar_registrants'] = mocker.patch(
-        'indico_vc_zoom.plugin.ZoomIndicoClient.batch_webinar_registrants')
-
-    zoom_api['list_meeting_registrants'].return_value = {'registrants': [{'id': 'reg123', 'email': 'test@example.com'}]}
-    zoom_api['list_webinar_registrants'].return_value = {'registrants': [{'id': 'reg123', 'email': 'test@example.com'}]}
-
-    return zoom_api
 
 
 def test_registration_sync_meeting(db, zoom_plugin, zoom_api_registrants, reg_form, create_zoom_meeting, test_client,

--- a/vc_zoom/tests/registration_test.py
+++ b/vc_zoom/tests/registration_test.py
@@ -99,7 +99,7 @@ def test_registration_sync_disabled(db, zoom_plugin, zoom_api_registrants, reg_f
 
 
 def test_registration_state_updated_approve(db, zoom_plugin, zoom_api_registrants, reg_form, create_zoom_meeting,
-                                             test_client, zoom_user):
+                                            test_client, zoom_user):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
     event.update_principal(zoom_user, full_access=True)
@@ -131,7 +131,7 @@ def test_registration_state_updated_approve(db, zoom_plugin, zoom_api_registrant
 
 
 def test_registration_state_updated_withdraw(db, zoom_plugin, zoom_api_registrants, reg_form, create_zoom_meeting,
-                                              test_client, zoom_user):
+                                             test_client, zoom_user):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
     event.update_principal(zoom_user, full_access=True)
@@ -166,8 +166,8 @@ def test_registration_state_updated_withdraw(db, zoom_plugin, zoom_api_registran
                for args, _kwargs in zoom_api_registrants['update_meeting_registrants_status'].call_args_list)
 
 
-def test_registration_sync_webinar(db, zoom_plugin, zoom_api_registrants, reg_form, create_zoom_meeting, mocker,
-                                   zoom_user):
+@pytest.mark.usefixtures('create_zoom_meeting')
+def test_registration_sync_webinar(db, zoom_plugin, zoom_api_registrants, reg_form, mocker, zoom_user):
     zoom_plugin.settings.set('allow_auto_register', True)
     zoom_plugin.settings.set('allow_webinars', True)
     event = reg_form.event
@@ -218,7 +218,7 @@ def test_registration_sync_webinar(db, zoom_plugin, zoom_api_registrants, reg_fo
 
 
 def test_registration_form_deleted_batches_removals(db, zoom_plugin, zoom_api_registrants, reg_form,
-                                                     create_zoom_meeting, test_client, zoom_user):
+                                                    create_zoom_meeting, test_client, zoom_user):
     """Deleting a form with multiple registrations should batch API calls (one list + one cancel per meeting)."""
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
@@ -271,9 +271,8 @@ def test_registration_form_deleted_batches_removals(db, zoom_plugin, zoom_api_re
     assert cancelled_emails == {'alice@example.com', 'bob@example.com'}
 
 
-@pytest.mark.usefixtures('request_context', 'smtp')
+@pytest.mark.usefixtures('request_context', 'db', 'smtp')
 def test_event_clone_skips_zoom_room_when_auto_register_enabled(
-    db,
     zoom_plugin,
     zoom_api_registrants,
     reg_form,
@@ -304,9 +303,9 @@ def test_event_clone_skips_zoom_room_when_auto_register_enabled(
     zoom_api_registrants['add_meeting_registrant'].assert_not_called()
 
 
-@pytest.mark.usefixtures('smtp')
-def test_vc_room_created_syncs_existing_registrations(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
-                                                       create_vc_room_with_assoc, make_complete_registration):
+@pytest.mark.usefixtures('db', 'smtp')
+def test_vc_room_created_syncs_existing_registrations(zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+                                                      create_vc_room_with_assoc, make_complete_registration):
     """Creating a Zoom meeting should sync pre-existing completed registrations."""
     event = reg_form.event
     make_complete_registration(reg_form, 'test@example.com', 'John', 'Doe')
@@ -324,9 +323,9 @@ def test_vc_room_created_syncs_existing_registrations(db, zoom_plugin, zoom_api_
     assert reg_data['first_name'] == 'John'
 
 
-@pytest.mark.usefixtures('smtp')
-def test_vc_room_created_auto_register_disabled(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
-                                                  create_vc_room_with_assoc, make_complete_registration):
+@pytest.mark.usefixtures('db', 'smtp')
+def test_vc_room_created_auto_register_disabled(zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+                                                create_vc_room_with_assoc, make_complete_registration):
     """No sync when auto_register is disabled."""
     event = reg_form.event
     make_complete_registration(reg_form, 'test@example.com', 'John', 'Doe')
@@ -343,7 +342,7 @@ def test_vc_room_created_auto_register_disabled(db, zoom_plugin, zoom_api_regist
 
 @pytest.mark.usefixtures('smtp')
 def test_vc_room_created_skips_non_complete_registrations(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
-                                                            create_vc_room_with_assoc):
+                                                          create_vc_room_with_assoc):
     """Only completed registrations are synced to Zoom on room creation."""
     event = reg_form.event
 
@@ -368,9 +367,9 @@ def test_vc_room_created_skips_non_complete_registrations(db, zoom_plugin, zoom_
     zoom_api_registrants['add_meeting_registrant'].assert_not_called()
 
 
-@pytest.mark.usefixtures('request_context', 'smtp')
+@pytest.mark.usefixtures('request_context', 'db', 'smtp')
 def test_enable_auto_register_skips_existing_zoom_registrants(
-    db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+    zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
     create_vc_room_with_assoc, make_complete_registration,
 ):
     """Enabling auto_register on an existing room should skip registrants already in Zoom."""
@@ -416,7 +415,8 @@ def test_vc_room_form_defaults_follow_auto_register_setting(
     assert defaults['password_visibility'] == expected_password_visibility
 
 
-def test_get_personalized_join_url_for_registered_user(db, smtp, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+@pytest.mark.usefixtures('db', 'smtp')
+def test_get_personalized_join_url_for_registered_user(zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
                                                        create_user, create_vc_room_with_assoc,
                                                        make_complete_registration):
     participant = create_user(2, email='jane.doe@megacorp.xyz')
@@ -435,9 +435,10 @@ def test_get_personalized_join_url_for_registered_user(db, smtp, zoom_plugin, zo
     zoom_api_registrants['list_meeting_registrants'].assert_called_once_with(vc_room.data['zoom_id'], page_size=300)
 
 
-def test_get_personalized_join_url_email_case_insensitive(db, smtp, zoom_plugin, zoom_api_registrants, reg_form,
-                                                           zoom_user, create_user, monkeypatch,
-                                                           create_vc_room_with_assoc, make_complete_registration):
+@pytest.mark.usefixtures('db', 'smtp')
+def test_get_personalized_join_url_email_case_insensitive(zoom_plugin, zoom_api_registrants, reg_form,
+                                                          zoom_user, create_user, monkeypatch,
+                                                          create_vc_room_with_assoc, make_complete_registration):
     """get_personalized_join_url must find the registrant even when _get_registrant_email returns mixed case."""
     participant = create_user(3, email='jane.doe@megacorp.xyz')
     event = reg_form.event
@@ -459,7 +460,7 @@ def test_get_personalized_join_url_email_case_insensitive(db, smtp, zoom_plugin,
 
 @pytest.mark.usefixtures('smtp')
 def test_collect_room_ops_deduplicates_by_email(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
-                                                  create_vc_room_with_assoc, make_complete_registration):
+                                                create_vc_room_with_assoc, make_complete_registration):
     """Two registrations with the same email (from different forms) should produce one Zoom registrant."""
     event = reg_form.event
 
@@ -517,7 +518,7 @@ def test_single_registrant_uses_individual_api(db, zoom_plugin, zoom_api_registr
 
 @pytest.mark.usefixtures('smtp')
 def test_multiple_registrants_uses_batch_api(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
-                                               create_vc_room_with_assoc, make_complete_registration):
+                                             create_vc_room_with_assoc, make_complete_registration):
     """Two or more registrants should use batch_meeting_registrants."""
     event = reg_form.event
     make_complete_registration(reg_form, 'alice@example.com', 'Alice', 'Smith')
@@ -587,9 +588,9 @@ def test_form_deletion_skips_remove_if_registered_via_other_form(db, zoom_plugin
     zoom_api_registrants['update_meeting_registrants_status'].assert_not_called()
 
 
-@pytest.mark.usefixtures('request_context', 'smtp')
-def test_registration_summary_shows_zoom_link(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
-                                                create_vc_room_with_assoc, make_complete_registration):
+@pytest.mark.usefixtures('request_context', 'db', 'smtp')
+def test_registration_summary_shows_zoom_link(zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+                                              create_vc_room_with_assoc, make_complete_registration):
     """The token-based registration summary should show the personalized Zoom join URL."""
     event = reg_form.event
     registration = make_complete_registration(reg_form, 'test@example.com', 'John', 'Doe')
@@ -606,8 +607,8 @@ def test_registration_summary_shows_zoom_link(db, zoom_plugin, zoom_api_registra
     assert 'https://example.com/personal' in html
 
 
-@pytest.mark.usefixtures('request_context', 'smtp')
-def test_registration_summary_hides_zoom_link_from_management(db, zoom_plugin, zoom_api_registrants, reg_form,
+@pytest.mark.usefixtures('request_context', 'db', 'smtp')
+def test_registration_summary_hides_zoom_link_from_management(zoom_plugin, zoom_api_registrants, reg_form,
                                                               zoom_user, create_vc_room_with_assoc,
                                                               make_complete_registration):
     """Management view should never see the participant's personal join URL."""
@@ -625,9 +626,9 @@ def test_registration_summary_hides_zoom_link_from_management(db, zoom_plugin, z
     assert html == ''
 
 
-@pytest.mark.usefixtures('request_context', 'smtp')
+@pytest.mark.usefixtures('request_context', 'db', 'smtp')
 def test_registration_summary_hides_zoom_link_when_auto_register_disabled(
-    db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+    zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
     create_vc_room_with_assoc, make_complete_registration,
 ):
     """Rooms without auto_register enabled must not produce a join link row."""
@@ -643,9 +644,9 @@ def test_registration_summary_hides_zoom_link_when_auto_register_disabled(
     zoom_api_registrants['list_meeting_registrants'].assert_not_called()
 
 
-@pytest.mark.usefixtures('request_context', 'smtp')
+@pytest.mark.usefixtures('request_context', 'db', 'smtp')
 def test_registration_summary_hides_zoom_link_if_not_registered_in_zoom(
-    db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+    zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
     create_vc_room_with_assoc, make_complete_registration,
 ):
     """If the registrant is not in Zoom (yet), no link row should be produced."""

--- a/vc_zoom/tests/registration_test.py
+++ b/vc_zoom/tests/registration_test.py
@@ -271,41 +271,6 @@ def test_registration_form_deleted_batches_removals(db, zoom_plugin, zoom_api_re
     assert cancelled_emails == {'alice@example.com', 'bob@example.com'}
 
 
-def _create_vc_room_with_assoc(db, event, zoom_user, *, auto_register=True, auto_checkin=False):
-    """Create a Zoom VCRoom + association for an event without going through the HTTP endpoint."""
-    vc_room = VCRoom(name='Test Meeting', type='zoom', status=VCRoomStatus.created, created_by_user=zoom_user)
-    vc_room.data = {
-        'zoom_id': 'zmeeting_manual',
-        'meeting_type': 'regular',
-        'host': 'User:1',
-        'auto_register': auto_register,
-        'auto_checkin': auto_checkin,
-    }
-    assoc = VCRoomEventAssociation(link_object=event, vc_room=vc_room, show=True,
-                                   data={'password_visibility': 'everyone'})
-    db.session.add(vc_room)
-    db.session.add(assoc)
-    db.session.flush()
-    return vc_room, assoc
-
-
-def _make_complete_registration(db, zoom_plugin, reg_form, email, first_name, last_name):
-    """Create a completed registration while auto_register is off to avoid triggering sync."""
-    data = {'email': email, 'first_name': first_name, 'last_name': last_name, 'affiliation': 'MegaCorp'}
-    form_data = {(getattr(f, 'html_field_name', None) or f.personal_data_type.name): data[f.personal_data_type.name]
-                 for f in reg_form.active_fields if f.personal_data_type and f.personal_data_type.name in data}
-    form_data['email'] = email
-
-    prev = zoom_plugin.settings.get('allow_auto_register')
-    zoom_plugin.settings.set('allow_auto_register', False)
-    registration = create_registration(reg_form, form_data)
-    db.session.flush()
-    registration.state = RegistrationState.complete
-    db.session.flush()
-    zoom_plugin.settings.set('allow_auto_register', prev)
-    return registration
-
-
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_event_clone_skips_zoom_room_when_auto_register_enabled(
     db,
@@ -313,13 +278,15 @@ def test_event_clone_skips_zoom_room_when_auto_register_enabled(
     zoom_api_registrants,
     reg_form,
     zoom_user,
+    create_vc_room_with_assoc,
+    make_complete_registration,
 ):
     event = reg_form.event
     set_feature_enabled(event, 'registration', True)
-    _make_complete_registration(db, zoom_plugin, reg_form, 'shared@example.com', 'Shared', 'User')
+    make_complete_registration(reg_form, 'shared@example.com', 'Shared', 'User')
 
     zoom_plugin.settings.set('allow_auto_register', True)
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user)
+    vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user)
     zoom_api_registrants['add_meeting_registrant'].reset_mock()
 
     session.set_session_user(zoom_user)
@@ -338,15 +305,16 @@ def test_event_clone_skips_zoom_room_when_auto_register_enabled(
 
 
 @pytest.mark.usefixtures('smtp')
-def test_vc_room_created_syncs_existing_registrations(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user):
+def test_vc_room_created_syncs_existing_registrations(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+                                                       create_vc_room_with_assoc, make_complete_registration):
     """Creating a Zoom meeting should sync pre-existing completed registrations."""
     event = reg_form.event
-    _make_complete_registration(db, zoom_plugin, reg_form, 'test@example.com', 'John', 'Doe')
+    make_complete_registration(reg_form, 'test@example.com', 'John', 'Doe')
 
     zoom_plugin.settings.set('allow_auto_register', True)
     zoom_api_registrants['add_meeting_registrant'].reset_mock()
 
-    vc_room, assoc = _create_vc_room_with_assoc(db, event, zoom_user)
+    vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
     signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
     zoom_plugin._flush_pending_registrations(None)
 
@@ -357,15 +325,16 @@ def test_vc_room_created_syncs_existing_registrations(db, zoom_plugin, zoom_api_
 
 
 @pytest.mark.usefixtures('smtp')
-def test_vc_room_created_auto_register_disabled(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user):
+def test_vc_room_created_auto_register_disabled(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+                                                  create_vc_room_with_assoc, make_complete_registration):
     """No sync when auto_register is disabled."""
     event = reg_form.event
-    _make_complete_registration(db, zoom_plugin, reg_form, 'test@example.com', 'John', 'Doe')
+    make_complete_registration(reg_form, 'test@example.com', 'John', 'Doe')
 
     zoom_plugin.settings.set('allow_auto_register', False)
     zoom_api_registrants['add_meeting_registrant'].reset_mock()
 
-    vc_room, assoc = _create_vc_room_with_assoc(db, event, zoom_user)
+    vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
     signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
     zoom_plugin._flush_pending_registrations(None)
 
@@ -373,7 +342,8 @@ def test_vc_room_created_auto_register_disabled(db, zoom_plugin, zoom_api_regist
 
 
 @pytest.mark.usefixtures('smtp')
-def test_vc_room_created_skips_non_complete_registrations(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user):
+def test_vc_room_created_skips_non_complete_registrations(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+                                                            create_vc_room_with_assoc):
     """Only completed registrations are synced to Zoom on room creation."""
     event = reg_form.event
 
@@ -391,7 +361,7 @@ def test_vc_room_created_skips_non_complete_registrations(db, zoom_plugin, zoom_
     zoom_plugin.settings.set('allow_auto_register', True)
     zoom_api_registrants['add_meeting_registrant'].reset_mock()
 
-    vc_room, assoc = _create_vc_room_with_assoc(db, event, zoom_user)
+    vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
     signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
     zoom_plugin._flush_pending_registrations(None)
 
@@ -400,15 +370,16 @@ def test_vc_room_created_skips_non_complete_registrations(db, zoom_plugin, zoom_
 
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_enable_auto_register_skips_existing_zoom_registrants(
-    db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user
+    db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+    create_vc_room_with_assoc, make_complete_registration,
 ):
     """Enabling auto_register on an existing room should skip registrants already in Zoom."""
     event = reg_form.event
-    _make_complete_registration(db, zoom_plugin, reg_form, 'existing@example.com', 'Already', 'Registered')
-    _make_complete_registration(db, zoom_plugin, reg_form, 'new@example.com', 'Brand', 'New')
+    make_complete_registration(reg_form, 'existing@example.com', 'Already', 'Registered')
+    make_complete_registration(reg_form, 'new@example.com', 'Brand', 'New')
 
     zoom_plugin.settings.set('allow_auto_register', True)
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=False)
+    vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=False)
 
     zoom_api_registrants['list_meeting_registrants'].return_value = {
         'registrants': [{'id': 'reg_existing', 'email': 'existing@example.com'}]
@@ -446,13 +417,14 @@ def test_vc_room_form_defaults_follow_auto_register_setting(
 
 
 def test_get_personalized_join_url_for_registered_user(db, smtp, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
-                                                       create_user):
+                                                       create_user, create_vc_room_with_assoc,
+                                                       make_complete_registration):
     participant = create_user(2, email='jane.doe@megacorp.xyz')
     event = reg_form.event
-    _make_complete_registration(db, zoom_plugin, reg_form, participant.email, 'Jane', 'Doe')
+    make_complete_registration(reg_form, participant.email, 'Jane', 'Doe')
 
     zoom_plugin.settings.set('allow_auto_register', True)
-    vc_room, assoc = _create_vc_room_with_assoc(db, event, zoom_user)
+    vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
     zoom_api_registrants['list_meeting_registrants'].return_value = {
         'registrants': [{'id': 'reg123', 'email': participant.email, 'join_url': 'https://example.com/personal'}]
     }
@@ -464,14 +436,15 @@ def test_get_personalized_join_url_for_registered_user(db, smtp, zoom_plugin, zo
 
 
 def test_get_personalized_join_url_email_case_insensitive(db, smtp, zoom_plugin, zoom_api_registrants, reg_form,
-                                                           zoom_user, create_user, monkeypatch):
+                                                           zoom_user, create_user, monkeypatch,
+                                                           create_vc_room_with_assoc, make_complete_registration):
     """get_personalized_join_url must find the registrant even when _get_registrant_email returns mixed case."""
     participant = create_user(3, email='jane.doe@megacorp.xyz')
     event = reg_form.event
-    _make_complete_registration(db, zoom_plugin, reg_form, participant.email, 'Jane', 'Doe')
+    make_complete_registration(reg_form, participant.email, 'Jane', 'Doe')
 
     zoom_plugin.settings.set('allow_auto_register', True)
-    vc_room, assoc = _create_vc_room_with_assoc(db, event, zoom_user)
+    vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
     # Simulate _get_registrant_email returning a mixed-case enterprise email
     monkeypatch.setattr(zoom_plugin, '_get_registrant_email', lambda reg: 'Jane.Doe@MegaCorp.XYZ')
     # _find_zoom_registrants normalises keys to lowercase, so the key is lowercased
@@ -485,7 +458,8 @@ def test_get_personalized_join_url_email_case_insensitive(db, smtp, zoom_plugin,
 
 
 @pytest.mark.usefixtures('smtp')
-def test_collect_room_ops_deduplicates_by_email(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user):
+def test_collect_room_ops_deduplicates_by_email(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+                                                  create_vc_room_with_assoc, make_complete_registration):
     """Two registrations with the same email (from different forms) should produce one Zoom registrant."""
     event = reg_form.event
 
@@ -499,14 +473,14 @@ def test_collect_room_ops_deduplicates_by_email(db, zoom_plugin, zoom_api_regist
     db.session.flush()
 
     # Register same email in both forms
-    reg1 = _make_complete_registration(db, zoom_plugin, reg_form, 'dupe@example.com', 'John', 'Doe')
-    reg2 = _make_complete_registration(db, zoom_plugin, reg_form_2, 'dupe@example.com', 'John', 'Doe')
+    reg1 = make_complete_registration(reg_form, 'dupe@example.com', 'John', 'Doe')
+    reg2 = make_complete_registration(reg_form_2, 'dupe@example.com', 'John', 'Doe')
     assert reg1.id != reg2.id
 
     zoom_plugin.settings.set('allow_auto_register', True)
     zoom_api_registrants['add_meeting_registrant'].reset_mock()
 
-    vc_room, assoc = _create_vc_room_with_assoc(db, event, zoom_user)
+    vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
     signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
     zoom_plugin._flush_pending_registrations(None)
 
@@ -517,7 +491,7 @@ def test_collect_room_ops_deduplicates_by_email(db, zoom_plugin, zoom_api_regist
 
 
 def test_single_registrant_uses_individual_api(db, zoom_plugin, zoom_api_registrants, reg_form, create_zoom_meeting,
-                                               test_client, zoom_user):
+                                               test_client, zoom_user, make_complete_registration):
     """A single registrant should use add_meeting_registrant, not batch."""
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
@@ -529,7 +503,7 @@ def test_single_registrant_uses_individual_api(db, zoom_plugin, zoom_api_registr
     vc_room = create_zoom_meeting(event, 'event')
     vc_room.data['auto_register'] = True
 
-    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'solo@example.com', 'Solo', 'User')
+    reg = make_complete_registration(reg_form, 'solo@example.com', 'Solo', 'User')
 
     zoom_api_registrants['add_meeting_registrant'].reset_mock()
     zoom_api_registrants['batch_meeting_registrants'].reset_mock()
@@ -542,10 +516,11 @@ def test_single_registrant_uses_individual_api(db, zoom_plugin, zoom_api_registr
 
 
 @pytest.mark.usefixtures('smtp')
-def test_multiple_registrants_uses_batch_api(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user):
+def test_multiple_registrants_uses_batch_api(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+                                               create_vc_room_with_assoc, make_complete_registration):
     """Two or more registrants should use batch_meeting_registrants."""
     event = reg_form.event
-    _make_complete_registration(db, zoom_plugin, reg_form, 'alice@example.com', 'Alice', 'Smith')
+    make_complete_registration(reg_form, 'alice@example.com', 'Alice', 'Smith')
 
     reg_form_2 = RegistrationForm(event=event, title='Second Form', currency='EUR')
     section = RegistrationFormSection(registration_form=reg_form_2, title='Personal Data',
@@ -554,13 +529,13 @@ def test_multiple_registrants_uses_batch_api(db, zoom_plugin, zoom_api_registran
     create_personal_data_fields(reg_form_2)
     event.registration_forms.append(reg_form_2)
     db.session.flush()
-    _make_complete_registration(db, zoom_plugin, reg_form_2, 'bob@example.com', 'Bob', 'Jones')
+    make_complete_registration(reg_form_2, 'bob@example.com', 'Bob', 'Jones')
 
     zoom_plugin.settings.set('allow_auto_register', True)
     zoom_api_registrants['add_meeting_registrant'].reset_mock()
     zoom_api_registrants['batch_meeting_registrants'].reset_mock()
 
-    vc_room, assoc = _create_vc_room_with_assoc(db, event, zoom_user)
+    vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
     signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
     zoom_plugin._flush_pending_registrations(None)
 
@@ -572,7 +547,8 @@ def test_multiple_registrants_uses_batch_api(db, zoom_plugin, zoom_api_registran
 
 
 def test_form_deletion_skips_remove_if_registered_via_other_form(db, zoom_plugin, zoom_api_registrants, reg_form,
-                                                                 create_zoom_meeting, test_client, zoom_user):
+                                                                 create_zoom_meeting, test_client, zoom_user,
+                                                                 make_complete_registration):
     """Deleting a form should not cancel a user's Zoom registration if they're still registered via another form."""
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
@@ -594,8 +570,8 @@ def test_form_deletion_skips_remove_if_registered_via_other_form(db, zoom_plugin
     db.session.flush()
 
     # Register same user in both forms
-    _make_complete_registration(db, zoom_plugin, reg_form, 'shared@example.com', 'Shared', 'User')
-    _make_complete_registration(db, zoom_plugin, reg_form_2, 'shared@example.com', 'Shared', 'User')
+    make_complete_registration(reg_form, 'shared@example.com', 'Shared', 'User')
+    make_complete_registration(reg_form_2, 'shared@example.com', 'Shared', 'User')
 
     # Mock list to return the shared registrant so the cancel would actually fire
     zoom_api_registrants['list_meeting_registrants'].return_value = {
@@ -612,13 +588,14 @@ def test_form_deletion_skips_remove_if_registered_via_other_form(db, zoom_plugin
 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
-def test_registration_summary_shows_zoom_link(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user):
+def test_registration_summary_shows_zoom_link(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+                                                create_vc_room_with_assoc, make_complete_registration):
     """The token-based registration summary should show the personalized Zoom join URL."""
     event = reg_form.event
-    registration = _make_complete_registration(db, zoom_plugin, reg_form, 'test@example.com', 'John', 'Doe')
+    registration = make_complete_registration(reg_form, 'test@example.com', 'John', 'Doe')
 
     zoom_plugin.settings.set('allow_auto_register', True)
-    _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True)
+    create_vc_room_with_assoc(event, zoom_user, auto_register=True)
 
     zoom_api_registrants['list_meeting_registrants'].return_value = {
         'registrants': [{'id': 'reg123', 'email': 'test@example.com', 'join_url': 'https://example.com/personal'}]
@@ -631,13 +608,14 @@ def test_registration_summary_shows_zoom_link(db, zoom_plugin, zoom_api_registra
 
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_registration_summary_hides_zoom_link_from_management(db, zoom_plugin, zoom_api_registrants, reg_form,
-                                                              zoom_user):
+                                                              zoom_user, create_vc_room_with_assoc,
+                                                              make_complete_registration):
     """Management view should never see the participant's personal join URL."""
     event = reg_form.event
-    registration = _make_complete_registration(db, zoom_plugin, reg_form, 'test@example.com', 'John', 'Doe')
+    registration = make_complete_registration(reg_form, 'test@example.com', 'John', 'Doe')
 
     zoom_plugin.settings.set('allow_auto_register', True)
-    _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True)
+    create_vc_room_with_assoc(event, zoom_user, auto_register=True)
     zoom_api_registrants['list_meeting_registrants'].return_value = {
         'registrants': [{'id': 'reg123', 'email': 'test@example.com', 'join_url': 'https://example.com/personal'}]
     }
@@ -649,14 +627,15 @@ def test_registration_summary_hides_zoom_link_from_management(db, zoom_plugin, z
 
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_registration_summary_hides_zoom_link_when_auto_register_disabled(
-    db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user
+    db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+    create_vc_room_with_assoc, make_complete_registration,
 ):
     """Rooms without auto_register enabled must not produce a join link row."""
     event = reg_form.event
-    registration = _make_complete_registration(db, zoom_plugin, reg_form, 'test@example.com', 'John', 'Doe')
+    registration = make_complete_registration(reg_form, 'test@example.com', 'John', 'Doe')
 
     zoom_plugin.settings.set('allow_auto_register', True)
-    _create_vc_room_with_assoc(db, event, zoom_user, auto_register=False)
+    create_vc_room_with_assoc(event, zoom_user, auto_register=False)
 
     html = zoom_plugin._render_registration_zoom_link(registration, from_management=False)
 
@@ -666,14 +645,15 @@ def test_registration_summary_hides_zoom_link_when_auto_register_disabled(
 
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_registration_summary_hides_zoom_link_if_not_registered_in_zoom(
-    db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user
+    db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+    create_vc_room_with_assoc, make_complete_registration,
 ):
     """If the registrant is not in Zoom (yet), no link row should be produced."""
     event = reg_form.event
-    registration = _make_complete_registration(db, zoom_plugin, reg_form, 'test@example.com', 'John', 'Doe')
+    registration = make_complete_registration(reg_form, 'test@example.com', 'John', 'Doe')
 
     zoom_plugin.settings.set('allow_auto_register', True)
-    _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True)
+    create_vc_room_with_assoc(event, zoom_user, auto_register=True)
     zoom_api_registrants['list_meeting_registrants'].return_value = {'registrants': []}
 
     html = zoom_plugin._render_registration_zoom_link(registration, from_management=False)

--- a/vc_zoom/tests/webhook_test.py
+++ b/vc_zoom/tests/webhook_test.py
@@ -49,8 +49,7 @@ def test_webhook_bad_signature_returns_403(db, test_client, zoom_plugin):
     ts = str(int(_time.time()))
     resp = test_client.post(
         '/api/plugin/zoom/webhook',
-        data=b'{"event":"meeting.updated","payload":{"object":{"id":"z1"}}}',
-        content_type='application/json',
+        json={'event': 'meeting.updated', 'payload': {'object': {'id': 'z1'}}},
         headers={'x-zm-request-timestamp': ts, 'x-zm-signature': 'v0=badsig'},
     )
     assert resp.status_code == 403
@@ -80,7 +79,7 @@ def test_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zo
     resp = webhook_client(payload)
     assert resp.status_code == 200
     db.session.refresh(reg)
-    assert reg.checked_in is True
+    assert reg.checked_in
     assert reg.checked_in_dt is not None
 
 
@@ -139,7 +138,7 @@ def test_participant_joined_skipped_when_auto_register_disabled(db, zoom_plugin,
     resp = webhook_client(payload)
     assert resp.status_code == 200
     db.session.refresh(reg)
-    assert reg.checked_in is False
+    assert not reg.checked_in
 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
@@ -159,7 +158,7 @@ def test_participant_joined_idempotent_when_already_checked_in(db, zoom_plugin, 
     }
     resp = webhook_client(payload)
     assert resp.status_code == 200
-    assert reg.checked_in is True
+    assert reg.checked_in
 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
@@ -190,4 +189,4 @@ def test_webinar_participant_joined_checks_in_registration(db, zoom_plugin, reg_
     resp = webhook_client(payload)
     assert resp.status_code == 200
     db.session.refresh(reg)
-    assert reg.checked_in is True
+    assert reg.checked_in

--- a/vc_zoom/tests/webhook_test.py
+++ b/vc_zoom/tests/webhook_test.py
@@ -62,7 +62,7 @@ def test_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zo
                                                     webhook_client):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True)
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, webhook_checkin=True)
 
     reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
     db.session.flush()
@@ -88,7 +88,7 @@ def test_participant_joined_emits_checkin_signal(db, zoom_plugin, reg_form, zoom
                                                   webhook_client, mocker):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True)
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, webhook_checkin=True)
 
     reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
     db.session.flush()
@@ -110,7 +110,7 @@ def test_participant_joined_emits_checkin_signal(db, zoom_plugin, reg_form, zoom
 def test_participant_joined_unknown_email_returns_200(db, zoom_plugin, reg_form, zoom_user, webhook_client):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True)
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, webhook_checkin=True)
     db.session.flush()
 
     payload = {
@@ -126,7 +126,27 @@ def test_participant_joined_skipped_when_auto_register_disabled(db, zoom_plugin,
                                                                   zoom_user, webhook_client):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=False)
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=False, webhook_checkin=True)
+
+    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
+    db.session.flush()
+
+    payload = {
+        'event': 'meeting.participant_joined',
+        'payload': {'object': {'id': vc_room.data['zoom_id'], 'participant': {'email': 'test@megacorp.xyz'}}},
+    }
+    resp = webhook_client(payload)
+    assert resp.status_code == 200
+    db.session.refresh(reg)
+    assert not reg.checked_in
+
+
+@pytest.mark.usefixtures('request_context', 'smtp')
+def test_participant_joined_skipped_when_webhook_checkin_disabled(db, zoom_plugin, reg_form,
+                                                                   zoom_user, webhook_client):
+    zoom_plugin.settings.set('allow_auto_register', True)
+    event = reg_form.event
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, webhook_checkin=False)
 
     reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
     db.session.flush()
@@ -146,7 +166,7 @@ def test_participant_joined_idempotent_when_already_checked_in(db, zoom_plugin, 
                                                                 zoom_user, webhook_client):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True)
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, webhook_checkin=True)
 
     reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
     reg.checked_in = True
@@ -173,6 +193,7 @@ def test_webinar_participant_joined_checks_in_registration(db, zoom_plugin, reg_
         'meeting_type': 'webinar',
         'host': 'User:1',
         'auto_register': True,
+        'webhook_checkin': True,
     }
     assoc = VCRoomEventAssociation(link_object=event, vc_room=vc_room, show=True,
                                    data={'password_visibility': 'everyone'})

--- a/vc_zoom/tests/webhook_test.py
+++ b/vc_zoom/tests/webhook_test.py
@@ -62,7 +62,7 @@ def test_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zo
                                                     webhook_client):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, webhook_checkin=True)
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, auto_checkin=True)
 
     reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
     db.session.flush()
@@ -88,7 +88,7 @@ def test_participant_joined_emits_checkin_signal(db, zoom_plugin, reg_form, zoom
                                                   webhook_client, mocker):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, webhook_checkin=True)
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, auto_checkin=True)
 
     reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
     db.session.flush()
@@ -110,7 +110,7 @@ def test_participant_joined_emits_checkin_signal(db, zoom_plugin, reg_form, zoom
 def test_participant_joined_unknown_email_returns_200(db, zoom_plugin, reg_form, zoom_user, webhook_client):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, webhook_checkin=True)
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, auto_checkin=True)
     db.session.flush()
 
     payload = {
@@ -126,7 +126,7 @@ def test_participant_joined_skipped_when_auto_register_disabled(db, zoom_plugin,
                                                                   zoom_user, webhook_client):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=False, webhook_checkin=True)
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=False, auto_checkin=True)
 
     reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
     db.session.flush()
@@ -142,11 +142,11 @@ def test_participant_joined_skipped_when_auto_register_disabled(db, zoom_plugin,
 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
-def test_participant_joined_skipped_when_webhook_checkin_disabled(db, zoom_plugin, reg_form,
+def test_participant_joined_skipped_when_auto_checkin_disabled(db, zoom_plugin, reg_form,
                                                                    zoom_user, webhook_client):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, webhook_checkin=False)
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, auto_checkin=False)
 
     reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
     db.session.flush()
@@ -166,7 +166,7 @@ def test_participant_joined_idempotent_when_already_checked_in(db, zoom_plugin, 
                                                                 zoom_user, webhook_client):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, webhook_checkin=True)
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, auto_checkin=True)
 
     reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
     reg.checked_in = True
@@ -193,7 +193,7 @@ def test_webinar_participant_joined_checks_in_registration(db, zoom_plugin, reg_
         'meeting_type': 'webinar',
         'host': 'User:1',
         'auto_register': True,
-        'webhook_checkin': True,
+        'auto_checkin': True,
     }
     assoc = VCRoomEventAssociation(link_object=event, vc_room=vc_room, show=True,
                                    data={'password_visibility': 'everyone'})

--- a/vc_zoom/tests/webhook_test.py
+++ b/vc_zoom/tests/webhook_test.py
@@ -1,0 +1,193 @@
+# This file is part of the Indico plugins.
+# Copyright (C) 2020 - 2026 CERN and ENEA
+#
+# The Indico plugins are free software; you can redistribute
+# them and/or modify them under the terms of the MIT License;
+# see the LICENSE file for more details.
+
+import hashlib
+import hmac as _hmac
+import json
+import time as _time
+
+import pytest
+from registration_test import _create_vc_room_with_assoc, _make_complete_registration
+
+from indico.core import signals
+from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation, VCRoomStatus
+
+
+TOKEN = 'test-webhook-secret'
+
+
+@pytest.fixture
+def webhook_client(test_client, zoom_plugin):
+    zoom_plugin.settings.set('webhook_token', TOKEN)
+
+    def _post(payload, *, timestamp=None):
+        if timestamp is None:
+            timestamp = str(int(_time.time()))
+        body = json.dumps(payload).encode()
+        sig = _hmac.new(TOKEN.encode(), b'v0:' + timestamp.encode() + b':' + body, hashlib.sha256).hexdigest()
+        return test_client.post(
+            '/api/plugin/zoom/webhook',
+            data=body,
+            content_type='application/json',
+            headers={
+                'x-zm-request-timestamp': timestamp,
+                'x-zm-signature': f'v0={sig}',
+            },
+        )
+
+    return _post
+
+
+# ── Security tests ────────────────────────────────────────────────────────────
+
+def test_webhook_bad_signature_returns_403(db, test_client, zoom_plugin):
+    zoom_plugin.settings.set('webhook_token', TOKEN)
+    ts = str(int(_time.time()))
+    resp = test_client.post(
+        '/api/plugin/zoom/webhook',
+        data=b'{"event":"meeting.updated","payload":{"object":{"id":"z1"}}}',
+        content_type='application/json',
+        headers={'x-zm-request-timestamp': ts, 'x-zm-signature': 'v0=badsig'},
+    )
+    assert resp.status_code == 403
+
+
+# ── participant_joined check-in tests ─────────────────────────────────────────
+
+@pytest.mark.usefixtures('request_context', 'smtp')
+def test_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zoom_user,
+                                                    webhook_client):
+    zoom_plugin.settings.set('allow_auto_register', True)
+    event = reg_form.event
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True)
+
+    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
+    db.session.flush()
+
+    payload = {
+        'event': 'meeting.participant_joined',
+        'payload': {
+            'object': {
+                'id': vc_room.data['zoom_id'],
+                'participant': {'email': 'test@megacorp.xyz'},
+            }
+        },
+    }
+    resp = webhook_client(payload)
+    assert resp.status_code == 200
+    db.session.refresh(reg)
+    assert reg.checked_in is True
+    assert reg.checked_in_dt is not None
+
+
+@pytest.mark.usefixtures('request_context', 'smtp')
+def test_participant_joined_emits_checkin_signal(db, zoom_plugin, reg_form, zoom_user,
+                                                  webhook_client, mocker):
+    zoom_plugin.settings.set('allow_auto_register', True)
+    event = reg_form.event
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True)
+
+    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
+    db.session.flush()
+
+    received = []
+    signals.event.registration_checkin_updated.connect(received.append, weak=False)
+
+    payload = {
+        'event': 'meeting.participant_joined',
+        'payload': {'object': {'id': vc_room.data['zoom_id'], 'participant': {'email': 'test@megacorp.xyz'}}},
+    }
+    webhook_client(payload)
+
+    signals.event.registration_checkin_updated.disconnect(received.append)
+    assert received == [reg]
+
+
+@pytest.mark.usefixtures('request_context', 'smtp')
+def test_participant_joined_unknown_email_returns_200(db, zoom_plugin, reg_form, zoom_user, webhook_client):
+    zoom_plugin.settings.set('allow_auto_register', True)
+    event = reg_form.event
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True)
+    db.session.flush()
+
+    payload = {
+        'event': 'meeting.participant_joined',
+        'payload': {'object': {'id': vc_room.data['zoom_id'], 'participant': {'email': 'nobody@megacorp.xyz'}}},
+    }
+    resp = webhook_client(payload)
+    assert resp.status_code == 200
+
+
+@pytest.mark.usefixtures('request_context', 'smtp')
+def test_participant_joined_skipped_when_auto_register_disabled(db, zoom_plugin, reg_form,
+                                                                  zoom_user, webhook_client):
+    zoom_plugin.settings.set('allow_auto_register', True)
+    event = reg_form.event
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=False)
+
+    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
+    db.session.flush()
+
+    payload = {
+        'event': 'meeting.participant_joined',
+        'payload': {'object': {'id': vc_room.data['zoom_id'], 'participant': {'email': 'test@megacorp.xyz'}}},
+    }
+    resp = webhook_client(payload)
+    assert resp.status_code == 200
+    db.session.refresh(reg)
+    assert reg.checked_in is False
+
+
+@pytest.mark.usefixtures('request_context', 'smtp')
+def test_participant_joined_idempotent_when_already_checked_in(db, zoom_plugin, reg_form,
+                                                                zoom_user, webhook_client):
+    zoom_plugin.settings.set('allow_auto_register', True)
+    event = reg_form.event
+    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True)
+
+    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
+    reg.checked_in = True
+    db.session.flush()
+
+    payload = {
+        'event': 'meeting.participant_joined',
+        'payload': {'object': {'id': vc_room.data['zoom_id'], 'participant': {'email': 'test@megacorp.xyz'}}},
+    }
+    resp = webhook_client(payload)
+    assert resp.status_code == 200
+    assert reg.checked_in is True
+
+
+@pytest.mark.usefixtures('request_context', 'smtp')
+def test_webinar_participant_joined_checks_in_registration(db, zoom_plugin, reg_form,
+                                                            zoom_user, webhook_client):
+    zoom_plugin.settings.set('allow_auto_register', True)
+    event = reg_form.event
+
+    vc_room = VCRoom(name='Test Webinar', type='zoom', status=VCRoomStatus.created, created_by_user=zoom_user)
+    vc_room.data = {
+        'zoom_id': 'zwebinar_test',
+        'meeting_type': 'webinar',
+        'host': 'User:1',
+        'auto_register': True,
+    }
+    assoc = VCRoomEventAssociation(link_object=event, vc_room=vc_room, show=True,
+                                   data={'password_visibility': 'everyone'})
+    db.session.add(vc_room)
+    db.session.add(assoc)
+
+    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'webinar@megacorp.xyz', 'Web', 'User')
+    db.session.flush()
+
+    payload = {
+        'event': 'webinar.participant_joined',
+        'payload': {'object': {'id': 'zwebinar_test', 'participant': {'email': 'webinar@megacorp.xyz'}}},
+    }
+    resp = webhook_client(payload)
+    assert resp.status_code == 200
+    db.session.refresh(reg)
+    assert reg.checked_in is True

--- a/vc_zoom/tests/webhook_test.py
+++ b/vc_zoom/tests/webhook_test.py
@@ -6,12 +6,11 @@
 # see the LICENSE file for more details.
 
 import hashlib
-import hmac as _hmac
+import hmac
 import json
-import time as _time
+import time
 
 import pytest
-from registration_test import _create_vc_room_with_assoc, _make_complete_registration
 
 from indico.core import signals
 from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation, VCRoomStatus
@@ -26,9 +25,9 @@ def webhook_client(test_client, zoom_plugin):
 
     def _post(payload, *, timestamp=None):
         if timestamp is None:
-            timestamp = str(int(_time.time()))
+            timestamp = str(int(time.time()))
         body = json.dumps(payload).encode()
-        sig = _hmac.new(TOKEN.encode(), b'v0:' + timestamp.encode() + b':' + body, hashlib.sha256).hexdigest()
+        sig = hmac.new(TOKEN.encode(), b'v0:' + timestamp.encode() + b':' + body, hashlib.sha256).hexdigest()
         return test_client.post(
             '/api/plugin/zoom/webhook',
             data=body,
@@ -46,7 +45,7 @@ def webhook_client(test_client, zoom_plugin):
 
 def test_webhook_bad_signature_returns_403(db, test_client, zoom_plugin):
     zoom_plugin.settings.set('webhook_token', TOKEN)
-    ts = str(int(_time.time()))
+    ts = str(int(time.time()))
     resp = test_client.post(
         '/api/plugin/zoom/webhook',
         json={'event': 'meeting.updated', 'payload': {'object': {'id': 'z1'}}},
@@ -58,13 +57,13 @@ def test_webhook_bad_signature_returns_403(db, test_client, zoom_plugin):
 # ── participant_joined check-in tests ─────────────────────────────────────────
 
 @pytest.mark.usefixtures('request_context', 'smtp')
-def test_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zoom_user,
-                                                    webhook_client):
+def test_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zoom_user, webhook_client,
+                                                    create_vc_room_with_assoc, make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, auto_checkin=True)
+    vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=True)
 
-    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
+    reg = make_complete_registration(reg_form, 'test@megacorp.xyz', 'Test', 'User')
     db.session.flush()
 
     payload = {
@@ -84,33 +83,32 @@ def test_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zo
 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
-def test_participant_joined_emits_checkin_signal(db, zoom_plugin, reg_form, zoom_user,
-                                                  webhook_client, mocker):
+def test_participant_joined_emits_checkin_signal(db, zoom_plugin, reg_form, zoom_user, webhook_client,
+                                                  create_vc_room_with_assoc, make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, auto_checkin=True)
+    vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=True)
 
-    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
+    reg = make_complete_registration(reg_form, 'test@megacorp.xyz', 'Test', 'User')
     db.session.flush()
 
     received = []
-    signals.event.registration_checkin_updated.connect(received.append, weak=False)
-
     payload = {
         'event': 'meeting.participant_joined',
         'payload': {'object': {'id': vc_room.data['zoom_id'], 'participant': {'email': 'test@megacorp.xyz'}}},
     }
-    webhook_client(payload)
+    with signals.event.registration_checkin_updated.connected_to(received.append):
+        webhook_client(payload)
 
-    signals.event.registration_checkin_updated.disconnect(received.append)
     assert received == [reg]
 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
-def test_participant_joined_unknown_email_returns_200(db, zoom_plugin, reg_form, zoom_user, webhook_client):
+def test_participant_joined_unknown_email_returns_200(db, zoom_plugin, reg_form, zoom_user, webhook_client,
+                                                       create_vc_room_with_assoc):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, auto_checkin=True)
+    vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=True)
     db.session.flush()
 
     payload = {
@@ -122,13 +120,14 @@ def test_participant_joined_unknown_email_returns_200(db, zoom_plugin, reg_form,
 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
-def test_participant_joined_skipped_when_auto_register_disabled(db, zoom_plugin, reg_form,
-                                                                  zoom_user, webhook_client):
+def test_participant_joined_skipped_when_auto_register_disabled(db, zoom_plugin, reg_form, zoom_user, webhook_client,
+                                                                  create_vc_room_with_assoc,
+                                                                  make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=False, auto_checkin=True)
+    vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=False, auto_checkin=True)
 
-    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
+    reg = make_complete_registration(reg_form, 'test@megacorp.xyz', 'Test', 'User')
     db.session.flush()
 
     payload = {
@@ -142,13 +141,14 @@ def test_participant_joined_skipped_when_auto_register_disabled(db, zoom_plugin,
 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
-def test_participant_joined_skipped_when_auto_checkin_disabled(db, zoom_plugin, reg_form,
-                                                                   zoom_user, webhook_client):
+def test_participant_joined_skipped_when_auto_checkin_disabled(db, zoom_plugin, reg_form, zoom_user, webhook_client,
+                                                                   create_vc_room_with_assoc,
+                                                                   make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, auto_checkin=False)
+    vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=False)
 
-    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
+    reg = make_complete_registration(reg_form, 'test@megacorp.xyz', 'Test', 'User')
     db.session.flush()
 
     payload = {
@@ -162,13 +162,14 @@ def test_participant_joined_skipped_when_auto_checkin_disabled(db, zoom_plugin, 
 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
-def test_participant_joined_idempotent_when_already_checked_in(db, zoom_plugin, reg_form,
-                                                                zoom_user, webhook_client):
+def test_participant_joined_idempotent_when_already_checked_in(db, zoom_plugin, reg_form, zoom_user, webhook_client,
+                                                                create_vc_room_with_assoc,
+                                                                make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
-    vc_room, _assoc = _create_vc_room_with_assoc(db, event, zoom_user, auto_register=True, auto_checkin=True)
+    vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=True)
 
-    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'test@megacorp.xyz', 'Test', 'User')
+    reg = make_complete_registration(reg_form, 'test@megacorp.xyz', 'Test', 'User')
     reg.checked_in = True
     db.session.flush()
 
@@ -182,8 +183,8 @@ def test_participant_joined_idempotent_when_already_checked_in(db, zoom_plugin, 
 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
-def test_webinar_participant_joined_checks_in_registration(db, zoom_plugin, reg_form,
-                                                            zoom_user, webhook_client):
+def test_webinar_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zoom_user, webhook_client,
+                                                            make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
 
@@ -200,7 +201,7 @@ def test_webinar_participant_joined_checks_in_registration(db, zoom_plugin, reg_
     db.session.add(vc_room)
     db.session.add(assoc)
 
-    reg = _make_complete_registration(db, zoom_plugin, reg_form, 'webinar@megacorp.xyz', 'Web', 'User')
+    reg = make_complete_registration(reg_form, 'webinar@megacorp.xyz', 'Web', 'User')
     db.session.flush()
 
     payload = {

--- a/vc_zoom/tests/webhook_test.py
+++ b/vc_zoom/tests/webhook_test.py
@@ -43,7 +43,8 @@ def webhook_client(test_client, zoom_plugin):
 
 # ── Security tests ────────────────────────────────────────────────────────────
 
-def test_webhook_bad_signature_returns_403(db, test_client, zoom_plugin):
+@pytest.mark.usefixtures('db')
+def test_webhook_bad_signature_returns_403(test_client, zoom_plugin):
     zoom_plugin.settings.set('webhook_token', TOKEN)
     ts = str(int(time.time()))
     resp = test_client.post(
@@ -58,7 +59,7 @@ def test_webhook_bad_signature_returns_403(db, test_client, zoom_plugin):
 
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zoom_user, webhook_client,
-                                                    create_vc_room_with_assoc, make_complete_registration):
+                                                   create_vc_room_with_assoc, make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
     vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=True)
@@ -84,7 +85,7 @@ def test_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zo
 
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_participant_joined_emits_checkin_signal(db, zoom_plugin, reg_form, zoom_user, webhook_client,
-                                                  create_vc_room_with_assoc, make_complete_registration):
+                                                 create_vc_room_with_assoc, make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
     vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=True)
@@ -105,7 +106,7 @@ def test_participant_joined_emits_checkin_signal(db, zoom_plugin, reg_form, zoom
 
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_participant_joined_unknown_email_returns_200(db, zoom_plugin, reg_form, zoom_user, webhook_client,
-                                                       create_vc_room_with_assoc):
+                                                      create_vc_room_with_assoc):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
     vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=True)
@@ -121,8 +122,7 @@ def test_participant_joined_unknown_email_returns_200(db, zoom_plugin, reg_form,
 
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_participant_joined_skipped_when_auto_register_disabled(db, zoom_plugin, reg_form, zoom_user, webhook_client,
-                                                                  create_vc_room_with_assoc,
-                                                                  make_complete_registration):
+                                                                create_vc_room_with_assoc, make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
     vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=False, auto_checkin=True)
@@ -142,8 +142,7 @@ def test_participant_joined_skipped_when_auto_register_disabled(db, zoom_plugin,
 
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_participant_joined_skipped_when_auto_checkin_disabled(db, zoom_plugin, reg_form, zoom_user, webhook_client,
-                                                                   create_vc_room_with_assoc,
-                                                                   make_complete_registration):
+                                                               create_vc_room_with_assoc, make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
     vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=False)
@@ -163,8 +162,7 @@ def test_participant_joined_skipped_when_auto_checkin_disabled(db, zoom_plugin, 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_participant_joined_idempotent_when_already_checked_in(db, zoom_plugin, reg_form, zoom_user, webhook_client,
-                                                                create_vc_room_with_assoc,
-                                                                make_complete_registration):
+                                                               create_vc_room_with_assoc, make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
     vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=True)
@@ -184,7 +182,7 @@ def test_participant_joined_idempotent_when_already_checked_in(db, zoom_plugin, 
 
 @pytest.mark.usefixtures('request_context', 'smtp')
 def test_webinar_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zoom_user, webhook_client,
-                                                            make_complete_registration):
+                                                           make_complete_registration):
     zoom_plugin.settings.set('allow_auto_register', True)
     event = reg_form.event
 

--- a/vc_zoom/tests/webhook_test.py
+++ b/vc_zoom/tests/webhook_test.py
@@ -48,7 +48,7 @@ def test_webhook_bad_signature_returns_403(db, test_client, zoom_plugin):
     ts = str(int(time.time()))
     resp = test_client.post(
         '/api/plugin/zoom/webhook',
-        json={'event': 'meeting.updated', 'payload': {'object': {'id': 'z1'}}},
+        json={'event': 'meeting.updated', 'payload': {'object': {'id': 100000}}},
         headers={'x-zm-request-timestamp': ts, 'x-zm-signature': 'v0=badsig'},
     )
     assert resp.status_code == 403
@@ -70,7 +70,7 @@ def test_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zo
         'event': 'meeting.participant_joined',
         'payload': {
             'object': {
-                'id': vc_room.data['zoom_id'],
+                'id': str(vc_room.data['zoom_id']),
                 'participant': {'email': 'test@megacorp.xyz'},
             }
         },
@@ -95,7 +95,7 @@ def test_participant_joined_emits_checkin_signal(db, zoom_plugin, reg_form, zoom
     received = []
     payload = {
         'event': 'meeting.participant_joined',
-        'payload': {'object': {'id': vc_room.data['zoom_id'], 'participant': {'email': 'test@megacorp.xyz'}}},
+        'payload': {'object': {'id': str(vc_room.data['zoom_id']), 'participant': {'email': 'test@megacorp.xyz'}}},
     }
     with signals.event.registration_checkin_updated.connected_to(received.append):
         webhook_client(payload)
@@ -113,7 +113,7 @@ def test_participant_joined_unknown_email_returns_200(db, zoom_plugin, reg_form,
 
     payload = {
         'event': 'meeting.participant_joined',
-        'payload': {'object': {'id': vc_room.data['zoom_id'], 'participant': {'email': 'nobody@megacorp.xyz'}}},
+        'payload': {'object': {'id': str(vc_room.data['zoom_id']), 'participant': {'email': 'nobody@megacorp.xyz'}}},
     }
     resp = webhook_client(payload)
     assert resp.status_code == 200
@@ -132,7 +132,7 @@ def test_participant_joined_skipped_when_auto_register_disabled(db, zoom_plugin,
 
     payload = {
         'event': 'meeting.participant_joined',
-        'payload': {'object': {'id': vc_room.data['zoom_id'], 'participant': {'email': 'test@megacorp.xyz'}}},
+        'payload': {'object': {'id': str(vc_room.data['zoom_id']), 'participant': {'email': 'test@megacorp.xyz'}}},
     }
     resp = webhook_client(payload)
     assert resp.status_code == 200
@@ -153,7 +153,7 @@ def test_participant_joined_skipped_when_auto_checkin_disabled(db, zoom_plugin, 
 
     payload = {
         'event': 'meeting.participant_joined',
-        'payload': {'object': {'id': vc_room.data['zoom_id'], 'participant': {'email': 'test@megacorp.xyz'}}},
+        'payload': {'object': {'id': str(vc_room.data['zoom_id']), 'participant': {'email': 'test@megacorp.xyz'}}},
     }
     resp = webhook_client(payload)
     assert resp.status_code == 200
@@ -175,7 +175,7 @@ def test_participant_joined_idempotent_when_already_checked_in(db, zoom_plugin, 
 
     payload = {
         'event': 'meeting.participant_joined',
-        'payload': {'object': {'id': vc_room.data['zoom_id'], 'participant': {'email': 'test@megacorp.xyz'}}},
+        'payload': {'object': {'id': str(vc_room.data['zoom_id']), 'participant': {'email': 'test@megacorp.xyz'}}},
     }
     resp = webhook_client(payload)
     assert resp.status_code == 200
@@ -190,7 +190,7 @@ def test_webinar_participant_joined_checks_in_registration(db, zoom_plugin, reg_
 
     vc_room = VCRoom(name='Test Webinar', type='zoom', status=VCRoomStatus.created, created_by_user=zoom_user)
     vc_room.data = {
-        'zoom_id': 'zwebinar_test',
+        'zoom_id': 26262601,
         'meeting_type': 'webinar',
         'host': 'User:1',
         'auto_register': True,
@@ -206,7 +206,7 @@ def test_webinar_participant_joined_checks_in_registration(db, zoom_plugin, reg_
 
     payload = {
         'event': 'webinar.participant_joined',
-        'payload': {'object': {'id': 'zwebinar_test', 'participant': {'email': 'webinar@megacorp.xyz'}}},
+        'payload': {'object': {'id': '26262601', 'participant': {'email': 'webinar@megacorp.xyz'}}},
     }
     resp = webhook_client(payload)
     assert resp.status_code == 200


### PR DESCRIPTION
This PR adds automatic check-in for Indico registrations when a participant joins a Zoom meeting.

When Zoom fires `meeting.participant_joined` or `webinar.participant_joined`, the webhook handler looks up the registration by the participant's email and marks it as checked in.