### PR TITLE
VC/Zoom: Push approval_type when auto_register toggles

### DIFF
--- a/vc_zoom/indico_vc_zoom/fixtures.py
+++ b/vc_zoom/indico_vc_zoom/fixtures.py
@@ -106,6 +106,9 @@ def zoom_api(zoom_plugin, create_user, mocker):
     api_update_meeting = mocker.patch('indico_vc_zoom.api.ZoomIndicoClient.update_meeting')
     api_update_meeting.return_value = {}
 
+    api_update_webinar = mocker.patch('indico_vc_zoom.api.ZoomIndicoClient.update_webinar')
+    api_update_webinar.return_value = {}
+
     user = create_user(1, email='don.orange@megacorp.xyz')
 
     api_get_user = mocker.patch('indico_vc_zoom.api.ZoomIndicoClient.get_user')
@@ -125,6 +128,7 @@ def zoom_api(zoom_plugin, create_user, mocker):
         'create_meeting': api_create_meeting,
         'get_meeting': api_get_meeting,
         'update_meeting': api_update_meeting,
+        'update_webinar': api_update_webinar,
         'api_delete_meeting': api_delete_meeting,
         'get_user': api_get_user,
     }

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -12,6 +12,7 @@ from wtforms.fields.simple import TextAreaField
 from wtforms.validators import DataRequired, ValidationError
 
 from indico.modules.vc.forms import VCRoomAttachFormBase, VCRoomFormBase
+from indico.util.date_time import now_utc
 from indico.util.string import is_valid_mail
 from indico.util.user import principal_from_identifier
 from indico.web.forms.base import generated_data
@@ -163,9 +164,42 @@ class VCRoomForm(VCRoomFormBase):
         if not current_plugin.settings.get('allow_auto_register'):
             del self.auto_register
 
+        self._auto_register_locked = False
+        if getattr(self, 'auto_register', None) is not None and self._is_link_target_in_past():
+            self._auto_register_locked = True
+            self.auto_register.render_kw = {'disabled': True}
+            self.auto_register.description = _(
+                'Automatic registration cannot be changed once the event has started. '
+                'Zoom does not honor registration changes on meetings without a future '
+                'start time.'
+            )
+
         if not current_plugin.settings.get('allow_language_interpretation'):
             del self.language_interpretation
             del self.interpreters
+
+    def _is_link_target_in_past(self):
+        """Return True if the form's link target is in the past.
+
+        Falls back to the event start_dt for new rooms where no link target is bound
+        yet. Zoom creates type=3/6/9 meetings when scheduling args are missing and
+        silently drops approval_type on those, so the auto_register toggle must be
+        treated as immutable in that case.
+        """
+        link_object = None
+        if self.vc_room is not None and self.vc_room.events:
+            link_object = self.vc_room.events[0].link_object
+        target = link_object if link_object is not None else self.event
+        return target.start_dt is None or target.start_dt < now_utc()
+
+    def validate_auto_register(self, field):
+        if self._auto_register_locked:
+            # The toggle is disabled in the UI for past/unscheduled targets, so an empty
+            # submission must not flip the persisted value. Restore the current state.
+            if self.vc_room is not None:
+                field.data = self.vc_room.data.get('auto_register', False)
+            else:
+                field.data = False
 
     def validate_host_choice(self, field):
         if field.data == 'myself':

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -406,8 +406,17 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
 
         flag_modified(vc_room, 'data')
 
-        # If auto_register was just enabled on an existing room, sync existing registrants
+        # If auto_register was just enabled on an existing room, push approval_type to Zoom
+        # before syncing registrants so the initial backfill can hit the registrants endpoint.
         if not is_new and not auto_register_before and vc_room.data.get('auto_register'):
+            is_webinar = vc_room.data.get('meeting_type') == 'webinar'
+            if not is_webinar:
+                try:
+                    update_zoom_meeting(vc_room.data['zoom_id'],
+                                        {'settings': {'approval_type': 0}}, is_webinar=False)
+                except HTTPError:
+                    self.logger.warning('Could not enable registration on Zoom meeting %s',
+                                        vc_room.data['zoom_id'])
             candidates = [
                 registration
                 for event_assoc in vc_room.events
@@ -422,7 +431,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                         self._find_zoom_registrants(ZoomIndicoClient(), vc_room, candidate_emails)
                     )
                 except HTTPError:
-                    zoom_type = 'webinar' if vc_room.data.get('meeting_type') == 'webinar' else 'meeting'
+                    zoom_type = 'webinar' if is_webinar else 'meeting'
                     self.logger.warning(f'Could not fetch registrants for Zoom {zoom_type} %s; '  # noqa: G004
                                         'syncing all existing registrants', vc_room.data['zoom_id'])
                     already_registered = set()
@@ -570,6 +579,9 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                 changes.setdefault('settings', {})['participant_video'] = not vc_room.data['mute_participant_video']
             if vc_room.data['waiting_room'] != zoom_meeting_settings['waiting_room']:
                 changes.setdefault('settings', {})['waiting_room'] = vc_room.data['waiting_room']
+            desired_approval_type = 0 if vc_room.data.get('auto_register') else 2
+            if zoom_meeting_settings.get('approval_type') != desired_approval_type:
+                changes.setdefault('settings', {})['approval_type'] = desired_approval_type
 
         if changes:
             update_zoom_meeting(vc_room.data['zoom_id'], changes, is_webinar=is_webinar)

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -393,9 +393,11 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                                 {'settings': {'approval_type': approval_type}},
                                 is_webinar=is_webinar)
         except HTTPError:
-            self.logger.warning('Could not push approval_type to Zoom %s %s',
-                                'webinar' if is_webinar else 'meeting',
-                                vc_room.data['zoom_id'])
+            zoom_type = 'webinar' if is_webinar else 'meeting'
+            self.logger.warning(
+                f'Could not push approval_type to Zoom {zoom_type} %s',  # noqa: G004
+                vc_room.data['zoom_id'],
+            )
             return False
         try:
             meeting, __ = fetch_zoom_meeting(vc_room)
@@ -403,11 +405,13 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             return False
         actual = meeting.get('settings', {}).get('approval_type')
         if actual != approval_type:
+            zoom_type = 'webinar' if is_webinar else 'meeting'
             self.logger.warning(
-                'Zoom %s %s did not honor approval_type=%s (got %s); this typically happens '
-                'on recurring meetings without a fixed time',
-                'webinar' if is_webinar else 'meeting',
-                vc_room.data['zoom_id'], approval_type, actual,
+                f'Zoom {zoom_type} %s did not honor approval_type=%s (got %s); this typically happens '  # noqa: G004
+                f'on recurring meetings without a fixed time',
+                vc_room.data['zoom_id'],
+                approval_type,
+                actual,
             )
             return False
         return True
@@ -630,11 +634,13 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             if approval_type_changed:
                 actual_approval_type = zoom_meeting.get('settings', {}).get('approval_type')
                 if actual_approval_type != desired_approval_type:
+                    zoom_type = 'webinar' if is_webinar else 'meeting'
                     self.logger.warning(
-                        'Zoom %s %s did not honor approval_type=%s (got %s); this typically '
-                        'happens on recurring meetings without a fixed time',
-                        'webinar' if is_webinar else 'meeting',
-                        vc_room.data['zoom_id'], desired_approval_type, actual_approval_type,
+                        f'Zoom {zoom_type} %s did not honor approval_type=%s (got %s); this typically '  # noqa: G004
+                        f'happens on recurring meetings without a fixed time',
+                        vc_room.data['zoom_id'],
+                        desired_approval_type,
+                        actual_approval_type,
                     )
 
     def refresh_room(self, vc_room, event):

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -410,13 +410,13 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         # before syncing registrants so the initial backfill can hit the registrants endpoint.
         if not is_new and not auto_register_before and vc_room.data.get('auto_register'):
             is_webinar = vc_room.data.get('meeting_type') == 'webinar'
-            if not is_webinar:
-                try:
-                    update_zoom_meeting(vc_room.data['zoom_id'],
-                                        {'settings': {'approval_type': 0}}, is_webinar=False)
-                except HTTPError:
-                    self.logger.warning('Could not enable registration on Zoom meeting %s',
-                                        vc_room.data['zoom_id'])
+            try:
+                update_zoom_meeting(vc_room.data['zoom_id'],
+                                    {'settings': {'approval_type': 0}}, is_webinar=is_webinar)
+            except HTTPError:
+                self.logger.warning('Could not enable registration on Zoom %s %s',
+                                    'webinar' if is_webinar else 'meeting',
+                                    vc_room.data['zoom_id'])
             candidates = [
                 registration
                 for event_assoc in vc_room.events
@@ -579,9 +579,10 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                 changes.setdefault('settings', {})['participant_video'] = not vc_room.data['mute_participant_video']
             if vc_room.data['waiting_room'] != zoom_meeting_settings['waiting_room']:
                 changes.setdefault('settings', {})['waiting_room'] = vc_room.data['waiting_room']
-            desired_approval_type = 0 if vc_room.data.get('auto_register') else 2
-            if zoom_meeting_settings.get('approval_type') != desired_approval_type:
-                changes.setdefault('settings', {})['approval_type'] = desired_approval_type
+
+        desired_approval_type = 0 if vc_room.data.get('auto_register') else 2
+        if zoom_meeting_settings.get('approval_type') != desired_approval_type:
+            changes.setdefault('settings', {})['approval_type'] = desired_approval_type
 
         if changes:
             update_zoom_meeting(vc_room.data['zoom_id'], changes, is_webinar=is_webinar)

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -644,11 +644,6 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             vc_room.data['meeting_type'] = 'webinar' if is_really_webinar else 'regular'
         vc_room.name = zoom_meeting['topic']
         zoom_approval_type = zoom_meeting['settings'].get('approval_type')
-        expected_approval_type = 0 if vc_room.data.get('auto_register') else 2
-        if zoom_approval_type != expected_approval_type and has_request_context():
-            flash(_('Zoom registration setting for this meeting differs from the Indico '
-                    'configuration. Save the videoconference to push the local setting to Zoom.'),
-                  'warning')
         vc_room.data.update({
             'description': zoom_meeting.get('agenda', ''),
             'zoom_id': zoom_meeting['id'],

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -381,6 +381,37 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
 
         return assoc_has_changed
 
+    def _push_approval_type(self, vc_room, approval_type, *, is_webinar):
+        """Push approval_type to Zoom and verify the change took effect.
+
+        Zoom returns 204 for an ``approval_type`` PATCH on recurring meetings without a
+        fixed time (type=3/9) but silently drops the value, so we read the meeting back
+        and log a warning when the new value did not stick.
+        """
+        try:
+            update_zoom_meeting(vc_room.data['zoom_id'],
+                                {'settings': {'approval_type': approval_type}},
+                                is_webinar=is_webinar)
+        except HTTPError:
+            self.logger.warning('Could not push approval_type to Zoom %s %s',
+                                'webinar' if is_webinar else 'meeting',
+                                vc_room.data['zoom_id'])
+            return False
+        try:
+            meeting, __ = fetch_zoom_meeting(vc_room)
+        except VCRoomNotFoundError:
+            return False
+        actual = meeting.get('settings', {}).get('approval_type')
+        if actual != approval_type:
+            self.logger.warning(
+                'Zoom %s %s did not honor approval_type=%s (got %s); this typically happens '
+                'on recurring meetings without a fixed time',
+                'webinar' if is_webinar else 'meeting',
+                vc_room.data['zoom_id'], approval_type, actual,
+            )
+            return False
+        return True
+
     def update_data_vc_room(self, vc_room, data, is_new=False):
         auto_register_before = vc_room.data.get('auto_register') if not is_new else None
         super().update_data_vc_room(vc_room, data, is_new=is_new)
@@ -406,38 +437,34 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
 
         flag_modified(vc_room, 'data')
 
-        # If auto_register was just enabled on an existing room, push approval_type to Zoom
-        # before syncing registrants so the initial backfill can hit the registrants endpoint.
-        if not is_new and not auto_register_before and vc_room.data.get('auto_register'):
+        # Push approval_type whenever auto_register is toggled. On enable we also sync any
+        # existing registrants so the initial backfill can hit the registrants endpoint.
+        if not is_new and auto_register_before != vc_room.data.get('auto_register'):
             is_webinar = vc_room.data.get('meeting_type') == 'webinar'
-            try:
-                update_zoom_meeting(vc_room.data['zoom_id'],
-                                    {'settings': {'approval_type': 0}}, is_webinar=is_webinar)
-            except HTTPError:
-                self.logger.warning('Could not enable registration on Zoom %s %s',
-                                    'webinar' if is_webinar else 'meeting',
-                                    vc_room.data['zoom_id'])
-            candidates = [
-                registration
-                for event_assoc in vc_room.events
-                for regform in event_assoc.event.registration_forms
-                for registration in regform.active_registrations
-                if registration.state == RegistrationState.complete
-            ]
-            if candidates:
-                candidate_emails = {self._get_registrant_email(r) for r in candidates}
-                try:
-                    already_registered = set(
-                        self._find_zoom_registrants(ZoomIndicoClient(), vc_room, candidate_emails)
-                    )
-                except HTTPError:
-                    zoom_type = 'webinar' if is_webinar else 'meeting'
-                    self.logger.warning(f'Could not fetch registrants for Zoom {zoom_type} %s; '  # noqa: G004
-                                        'syncing all existing registrants', vc_room.data['zoom_id'])
-                    already_registered = set()
-                for registration in candidates:
-                    if self._get_registrant_email(registration).lower() not in already_registered:
-                        self._queue_registration_sync(registration, remove=False)
+            desired_approval_type = 0 if vc_room.data.get('auto_register') else 2
+            self._push_approval_type(vc_room, desired_approval_type, is_webinar=is_webinar)
+            if vc_room.data.get('auto_register'):
+                candidates = [
+                    registration
+                    for event_assoc in vc_room.events
+                    for regform in event_assoc.event.registration_forms
+                    for registration in regform.active_registrations
+                    if registration.state == RegistrationState.complete
+                ]
+                if candidates:
+                    candidate_emails = {self._get_registrant_email(r) for r in candidates}
+                    try:
+                        already_registered = set(
+                            self._find_zoom_registrants(ZoomIndicoClient(), vc_room, candidate_emails)
+                        )
+                    except HTTPError:
+                        zoom_type = 'webinar' if is_webinar else 'meeting'
+                        self.logger.warning(f'Could not fetch registrants for Zoom {zoom_type} %s; '  # noqa: G004
+                                            'syncing all existing registrants', vc_room.data['zoom_id'])
+                        already_registered = set()
+                    for registration in candidates:
+                        if self._get_registrant_email(registration).lower() not in already_registered:
+                            self._queue_registration_sync(registration, remove=False)
 
     def create_room(self, vc_room, event):
         """Create a new Zoom meeting for an event, given a VC room.
@@ -458,6 +485,14 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         link_obj = vc_room_assoc.link_object
         is_webinar = vc_room.data.setdefault('meeting_type', 'regular') == 'webinar'
         scheduling_args = get_schedule_args(link_obj) if link_obj.start_dt else {}
+
+        # Zoom only honors approval_type on meetings with a fixed start time (type=2/5).
+        # Without scheduling_args the meeting becomes type=3/6/9, which silently drops the
+        # registration setting, so refuse to create such a room with auto_register enabled.
+        if vc_room.data.get('auto_register') and not scheduling_args:
+            raise VCRoomError(_('Automatic registration is not supported for events that have '
+                                'already started or have no scheduled start time. Disable '
+                                'automatic registration or reschedule the event in the future.'))
 
         try:
             settings = {
@@ -581,7 +616,8 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                 changes.setdefault('settings', {})['waiting_room'] = vc_room.data['waiting_room']
 
         desired_approval_type = 0 if vc_room.data.get('auto_register') else 2
-        if zoom_meeting_settings.get('approval_type') != desired_approval_type:
+        approval_type_changed = zoom_meeting_settings.get('approval_type') != desired_approval_type
+        if approval_type_changed:
             changes.setdefault('settings', {})['approval_type'] = desired_approval_type
 
         if changes:
@@ -589,6 +625,17 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             # always refresh meeting URL (it may have changed if password changed)
             zoom_meeting, _is_webinar = fetch_zoom_meeting(vc_room, client=client)
             vc_room.data.update(get_url_data_args(zoom_meeting['join_url']))
+            # Zoom silently drops approval_type on recurring meetings without a fixed time
+            # (type=3/9), so verify it stuck against the refreshed snapshot we just fetched.
+            if approval_type_changed:
+                actual_approval_type = zoom_meeting.get('settings', {}).get('approval_type')
+                if actual_approval_type != desired_approval_type:
+                    self.logger.warning(
+                        'Zoom %s %s did not honor approval_type=%s (got %s); this typically '
+                        'happens on recurring meetings without a fixed time',
+                        'webinar' if is_webinar else 'meeting',
+                        vc_room.data['zoom_id'], desired_approval_type, actual_approval_type,
+                    )
 
     def refresh_room(self, vc_room, event):
         is_webinar = vc_room.data['meeting_type'] == 'webinar'
@@ -596,6 +643,12 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         if is_webinar != is_really_webinar:
             vc_room.data['meeting_type'] = 'webinar' if is_really_webinar else 'regular'
         vc_room.name = zoom_meeting['topic']
+        zoom_approval_type = zoom_meeting['settings'].get('approval_type')
+        expected_approval_type = 0 if vc_room.data.get('auto_register') else 2
+        if zoom_approval_type != expected_approval_type and has_request_context():
+            flash(_('Zoom registration setting for this meeting differs from the Indico '
+                    'configuration. Save the videoconference to push the local setting to Zoom.'),
+                  'warning')
         vc_room.data.update({
             'description': zoom_meeting.get('agenda', ''),
             'zoom_id': zoom_meeting['id'],
@@ -613,7 +666,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             'mute_participant_video': not zoom_meeting['settings'].get('participant_video'),
             'waiting_room': zoom_meeting['settings'].get('waiting_room'),
             'alternative_hosts': process_alternative_hosts(zoom_meeting['settings'].get('alternative_hosts')),
-            'registration_required': zoom_meeting['settings'].get('approval_type') != 2,
+            'registration_required': zoom_approval_type != 2,
         })
         vc_room.data.update(get_url_data_args(zoom_meeting['join_url']))
         flag_modified(vc_room, 'data')

--- a/vc_zoom/tests/operation_test.py
+++ b/vc_zoom/tests/operation_test.py
@@ -10,8 +10,32 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from indico.modules.vc.exceptions import VCRoomError
+from indico.web.forms.base import FormDefaults
+
 
 TZ = ZoneInfo('Europe/Zurich')
+
+
+def _make_zoom_form(zoom_plugin, app, event, vc_room=None):
+    from indico_vc_zoom.forms import VCRoomForm
+
+    zoom_plugin.settings.set('allow_auto_register', True)
+    defaults = FormDefaults({
+        'name': 'Test',
+        'password': '12345678',
+        'host_choice': 'myself',
+        'description': '',
+        'meeting_type': 'regular',
+        'linking': 'event',
+        'mute_audio': True,
+        'mute_host_video': True,
+        'mute_participant_video': True,
+        'waiting_room': False,
+        'auto_register': vc_room.data.get('auto_register', False) if vc_room is not None else False,
+    })
+    with app.test_request_context(), zoom_plugin.plugin_context():
+        return VCRoomForm(prefix='vc-', obj=defaults, event=event, vc_room=vc_room)
 
 
 def _aligned_meeting(meeting_id, *, approval_type):
@@ -28,6 +52,7 @@ def _aligned_meeting(meeting_id, *, approval_type):
             'mute_upon_entry': True,
             'participant_video': False,
             'waiting_room': False,
+            'alternative_hosts': '',
             'approval_type': approval_type,
         },
     }
@@ -136,8 +161,13 @@ def test_update_room_pushes_approval_type(
 
 
 @pytest.mark.parametrize('meeting_type', ('regular', 'webinar'))
+@pytest.mark.parametrize(('auto_register_before', 'auto_register_after', 'expected_approval_type'), (
+    (False, True, 0),
+    (True, False, 2),
+))
 def test_update_data_vc_room_pushes_approval_type_before_sync(
-    create_event, create_zoom_meeting, zoom_plugin, zoom_api, meeting_type,
+    mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api, meeting_type,
+    auto_register_before, auto_register_after, expected_approval_type,
 ):
     event = create_event(
         creator=zoom_api['user'],
@@ -149,15 +179,177 @@ def test_update_data_vc_room_pushes_approval_type_before_sync(
 
     vc_room = create_zoom_meeting(event, 'event')
     vc_room.data['meeting_type'] = meeting_type
-    vc_room.data['auto_register'] = False
+    vc_room.data['auto_register'] = auto_register_before
 
     is_webinar = meeting_type == 'webinar'
+    mocker.patch(
+        'indico_vc_zoom.plugin.fetch_zoom_meeting',
+        return_value=(_aligned_meeting('zmeeting1', approval_type=expected_approval_type), is_webinar),
+    )
     api_mock = zoom_api['update_webinar' if is_webinar else 'update_meeting']
     other_mock = zoom_api['update_meeting' if is_webinar else 'update_webinar']
     api_mock.reset_mock()
     other_mock.reset_mock()
 
-    zoom_plugin.update_data_vc_room(vc_room, {'auto_register': True})
+    zoom_plugin.update_data_vc_room(vc_room, {'auto_register': auto_register_after})
 
-    api_mock.assert_called_once_with('zmeeting1', {'settings': {'approval_type': 0}})
+    api_mock.assert_called_once_with('zmeeting1', {'settings': {'approval_type': expected_approval_type}})
     other_mock.assert_not_called()
+
+
+def test_create_room_blocks_past_event_with_auto_register(
+    create_event, create_zoom_meeting, zoom_plugin, zoom_api,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['auto_register'] = True
+    zoom_api['create_meeting'].reset_mock()
+
+    with pytest.raises(VCRoomError):
+        zoom_plugin.create_room(vc_room, event)
+
+    zoom_api['create_meeting'].assert_not_called()
+
+
+def test_refresh_room_flashes_on_approval_type_divergence(
+    mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['auto_register'] = True  # local expects approval_type=0
+
+    mocker.patch(
+        'indico_vc_zoom.plugin.fetch_zoom_meeting',
+        return_value=(_aligned_meeting('zmeeting1', approval_type=2), False),
+    )
+    mocker.patch('indico_vc_zoom.plugin.has_request_context', return_value=True)
+    flash_mock = mocker.patch('indico_vc_zoom.plugin.flash')
+
+    zoom_plugin.refresh_room(vc_room, event)
+
+    flash_mock.assert_called_once()
+    args, _kwargs = flash_mock.call_args
+    assert 'Zoom registration setting' in str(args[0])
+    assert args[1] == 'warning'
+
+
+@pytest.mark.parametrize('is_webinar', (False, True))
+def test_push_approval_type_warns_when_zoom_drops_patch(
+    mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api, is_webinar,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+
+    # Zoom accepts the PATCH (no error) but the read-back shows the value was not honored
+    mocker.patch(
+        'indico_vc_zoom.plugin.fetch_zoom_meeting',
+        return_value=(_aligned_meeting('zmeeting1', approval_type=2), is_webinar),
+    )
+    warning_mock = mocker.patch.object(zoom_plugin.logger, 'warning')
+
+    result = zoom_plugin._push_approval_type(vc_room, 0, is_webinar=is_webinar)
+
+    assert result is False
+    warning_mock.assert_called_once()
+    assert 'did not honor approval_type' in warning_mock.call_args.args[0]
+
+
+def test_update_room_warns_when_zoom_drops_approval_type_patch(
+    mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['auto_register'] = True
+
+    # Both the pre- and post-PATCH fetches return approval_type=2 (Zoom dropped the change)
+    mocker.patch(
+        'indico_vc_zoom.plugin.fetch_zoom_meeting',
+        return_value=(_aligned_meeting('zmeeting1', approval_type=2), False),
+    )
+    warning_mock = mocker.patch.object(zoom_plugin.logger, 'warning')
+
+    zoom_plugin.update_room(vc_room, vc_room.events[0].event)
+
+    warning_mock.assert_called_once()
+    assert 'did not honor approval_type' in warning_mock.call_args.args[0]
+
+
+def test_auto_register_locked_for_past_event(zoom_plugin, app, create_event, zoom_api):
+    past_event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Past event',
+        creator_has_privileges=True,
+    )
+
+    form = _make_zoom_form(zoom_plugin, app, past_event)
+
+    assert form._auto_register_locked is True
+    assert form.auto_register.render_kw == {'disabled': True}
+    assert 'cannot be changed' in str(form.auto_register.description)
+
+
+def test_auto_register_not_locked_for_future_event(zoom_plugin, app, create_event, zoom_api):
+    future_event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2099, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2099, 3, 1, 18, 0, tzinfo=TZ),
+        title='Future event',
+        creator_has_privileges=True,
+    )
+
+    form = _make_zoom_form(zoom_plugin, app, future_event)
+
+    assert form._auto_register_locked is False
+    assert not (form.auto_register.render_kw or {}).get('disabled')
+
+
+def test_auto_register_validator_preserves_value_when_locked(
+    zoom_plugin, app, create_event, create_zoom_meeting, zoom_api,
+):
+    past_event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Past event',
+        creator_has_privileges=True,
+    )
+    vc_room = create_zoom_meeting(past_event, 'event')
+    vc_room.data['auto_register'] = True  # currently enabled
+
+    form = _make_zoom_form(zoom_plugin, app, past_event, vc_room=vc_room)
+
+    # Simulate a disabled checkbox not being submitted (BooleanField parses to False)
+    form.auto_register.data = False
+    form.validate_auto_register(form.auto_register)
+
+    assert form.auto_register.data is True

--- a/vc_zoom/tests/operation_test.py
+++ b/vc_zoom/tests/operation_test.py
@@ -8,8 +8,29 @@
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
+import pytest
+
 
 TZ = ZoneInfo('Europe/Zurich')
+
+
+def _aligned_meeting(meeting_id, *, approval_type):
+    return {
+        'id': meeting_id,
+        'join_url': 'https://example.com/kitties',
+        'start_url': 'https://example.com/puppies',
+        'password': '13371337',
+        'host_id': 'don.orange@megacorp.xyz',
+        'topic': 'Zoom Meeting',
+        'agenda': 'nothing to add',
+        'settings': {
+            'host_video': False,
+            'mute_upon_entry': True,
+            'participant_video': False,
+            'waiting_room': False,
+            'approval_type': approval_type,
+        },
+    }
 
 
 def test_room_creation(create_zoom_meeting, zoom_api, create_event):
@@ -52,7 +73,8 @@ def test_password_change(create_user, mocker, create_event, create_zoom_meeting,
                 'host_video': False,
                 'mute_upon_entry': True,
                 'participant_video': False,
-                'waiting_room': False
+                'waiting_room': False,
+                'approval_type': 2,
             }
         }
         _get_meeting.called = True
@@ -68,3 +90,106 @@ def test_password_change(create_user, mocker, create_event, create_zoom_meeting,
 
     assert vc_room.data['password'] == '12341234'
     assert vc_room.data['url'] == 'https://example.com/llamas'
+
+
+@pytest.mark.parametrize(('auto_register_before', 'auto_register_after', 'current_approval_type', 'expected'), (
+    (False, True, 2, {'settings': {'approval_type': 0}}),
+    (True, False, 0, {'settings': {'approval_type': 2}}),
+    (True, True, 0, None),
+    (False, False, 2, None),
+))
+def test_update_room_pushes_approval_type(
+    mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api,
+    auto_register_before, auto_register_after, current_approval_type, expected,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['auto_register'] = auto_register_after
+
+    zoom_api['get_meeting'].side_effect = (
+        lambda meeting_id, *a, **kw: _aligned_meeting(meeting_id, approval_type=current_approval_type)
+    )
+
+    zoom_api['update_meeting'].reset_mock()
+    zoom_plugin.update_room(vc_room, vc_room.events[0].event)
+
+    if expected is None:
+        zoom_api['update_meeting'].assert_not_called()
+    else:
+        zoom_api['update_meeting'].assert_called_with('zmeeting1', expected)
+
+
+def test_update_data_vc_room_pushes_approval_type_before_sync(
+    create_event, create_zoom_meeting, zoom_plugin, zoom_api,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['auto_register'] = False
+
+    zoom_api['update_meeting'].reset_mock()
+    zoom_plugin.update_data_vc_room(vc_room, {'auto_register': True})
+
+    zoom_api['update_meeting'].assert_called_once_with('zmeeting1', {'settings': {'approval_type': 0}})
+
+
+def test_update_data_vc_room_skips_approval_type_for_webinar(
+    create_event, create_zoom_meeting, zoom_plugin, zoom_api,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['meeting_type'] = 'webinar'
+    vc_room.data['auto_register'] = False
+
+    zoom_api['update_meeting'].reset_mock()
+    zoom_plugin.update_data_vc_room(vc_room, {'auto_register': True})
+
+    zoom_api['update_meeting'].assert_not_called()
+
+
+def test_update_room_skips_approval_type_for_webinar(
+    mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['meeting_type'] = 'webinar'
+    vc_room.data['auto_register'] = True
+
+    mocker.patch(
+        'indico_vc_zoom.plugin.fetch_zoom_meeting',
+        return_value=(_aligned_meeting('zmeeting1', approval_type=2), True),
+    )
+
+    zoom_api['update_meeting'].reset_mock()
+    zoom_plugin.update_room(vc_room, vc_room.events[0].event)
+
+    for call in zoom_api['update_meeting'].call_args_list:
+        settings = (call.args[1] if len(call.args) > 1 else call.kwargs.get('changes', {})).get('settings', {})
+        assert 'approval_type' not in settings

--- a/vc_zoom/tests/operation_test.py
+++ b/vc_zoom/tests/operation_test.py
@@ -218,35 +218,6 @@ def test_create_room_blocks_past_event_with_auto_register(
     zoom_api['create_meeting'].assert_not_called()
 
 
-def test_refresh_room_flashes_on_approval_type_divergence(
-    mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api,
-):
-    event = create_event(
-        creator=zoom_api['user'],
-        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
-        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
-        title='Test Event #1',
-        creator_has_privileges=True,
-    )
-
-    vc_room = create_zoom_meeting(event, 'event')
-    vc_room.data['auto_register'] = True  # local expects approval_type=0
-
-    mocker.patch(
-        'indico_vc_zoom.plugin.fetch_zoom_meeting',
-        return_value=(_aligned_meeting('zmeeting1', approval_type=2), False),
-    )
-    mocker.patch('indico_vc_zoom.plugin.has_request_context', return_value=True)
-    flash_mock = mocker.patch('indico_vc_zoom.plugin.flash')
-
-    zoom_plugin.refresh_room(vc_room, event)
-
-    flash_mock.assert_called_once()
-    args, _kwargs = flash_mock.call_args
-    assert 'Zoom registration setting' in str(args[0])
-    assert args[1] == 'warning'
-
-
 @pytest.mark.parametrize('is_webinar', (False, True))
 def test_push_approval_type_warns_when_zoom_drops_patch(
     mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api, is_webinar,

--- a/vc_zoom/tests/operation_test.py
+++ b/vc_zoom/tests/operation_test.py
@@ -92,6 +92,7 @@ def test_password_change(create_user, mocker, create_event, create_zoom_meeting,
     assert vc_room.data['url'] == 'https://example.com/llamas'
 
 
+@pytest.mark.parametrize('meeting_type', ('regular', 'webinar'))
 @pytest.mark.parametrize(('auto_register_before', 'auto_register_after', 'current_approval_type', 'expected'), (
     (False, True, 2, {'settings': {'approval_type': 0}}),
     (True, False, 0, {'settings': {'approval_type': 2}}),
@@ -100,7 +101,7 @@ def test_password_change(create_user, mocker, create_event, create_zoom_meeting,
 ))
 def test_update_room_pushes_approval_type(
     mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api,
-    auto_register_before, auto_register_after, current_approval_type, expected,
+    auto_register_before, auto_register_after, current_approval_type, expected, meeting_type,
 ):
     event = create_event(
         creator=zoom_api['user'],
@@ -111,85 +112,52 @@ def test_update_room_pushes_approval_type(
     )
 
     vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['meeting_type'] = meeting_type
     vc_room.data['auto_register'] = auto_register_after
 
-    zoom_api['get_meeting'].side_effect = (
-        lambda meeting_id, *a, **kw: _aligned_meeting(meeting_id, approval_type=current_approval_type)
-    )
-
-    zoom_api['update_meeting'].reset_mock()
-    zoom_plugin.update_room(vc_room, vc_room.events[0].event)
-
-    if expected is None:
-        zoom_api['update_meeting'].assert_not_called()
-    else:
-        zoom_api['update_meeting'].assert_called_with('zmeeting1', expected)
-
-
-def test_update_data_vc_room_pushes_approval_type_before_sync(
-    create_event, create_zoom_meeting, zoom_plugin, zoom_api,
-):
-    event = create_event(
-        creator=zoom_api['user'],
-        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
-        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
-        title='Test Event #1',
-        creator_has_privileges=True,
-    )
-
-    vc_room = create_zoom_meeting(event, 'event')
-    vc_room.data['auto_register'] = False
-
-    zoom_api['update_meeting'].reset_mock()
-    zoom_plugin.update_data_vc_room(vc_room, {'auto_register': True})
-
-    zoom_api['update_meeting'].assert_called_once_with('zmeeting1', {'settings': {'approval_type': 0}})
-
-
-def test_update_data_vc_room_skips_approval_type_for_webinar(
-    create_event, create_zoom_meeting, zoom_plugin, zoom_api,
-):
-    event = create_event(
-        creator=zoom_api['user'],
-        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
-        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
-        title='Test Event #1',
-        creator_has_privileges=True,
-    )
-
-    vc_room = create_zoom_meeting(event, 'event')
-    vc_room.data['meeting_type'] = 'webinar'
-    vc_room.data['auto_register'] = False
-
-    zoom_api['update_meeting'].reset_mock()
-    zoom_plugin.update_data_vc_room(vc_room, {'auto_register': True})
-
-    zoom_api['update_meeting'].assert_not_called()
-
-
-def test_update_room_skips_approval_type_for_webinar(
-    mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api,
-):
-    event = create_event(
-        creator=zoom_api['user'],
-        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
-        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
-        title='Test Event #1',
-        creator_has_privileges=True,
-    )
-
-    vc_room = create_zoom_meeting(event, 'event')
-    vc_room.data['meeting_type'] = 'webinar'
-    vc_room.data['auto_register'] = True
-
+    is_webinar = meeting_type == 'webinar'
     mocker.patch(
         'indico_vc_zoom.plugin.fetch_zoom_meeting',
-        return_value=(_aligned_meeting('zmeeting1', approval_type=2), True),
+        return_value=(_aligned_meeting('zmeeting1', approval_type=current_approval_type), is_webinar),
     )
 
-    zoom_api['update_meeting'].reset_mock()
+    api_mock = zoom_api['update_webinar' if is_webinar else 'update_meeting']
+    other_mock = zoom_api['update_meeting' if is_webinar else 'update_webinar']
+    api_mock.reset_mock()
+    other_mock.reset_mock()
+
     zoom_plugin.update_room(vc_room, vc_room.events[0].event)
 
-    for call in zoom_api['update_meeting'].call_args_list:
-        settings = (call.args[1] if len(call.args) > 1 else call.kwargs.get('changes', {})).get('settings', {})
-        assert 'approval_type' not in settings
+    other_mock.assert_not_called()
+    if expected is None:
+        api_mock.assert_not_called()
+    else:
+        api_mock.assert_called_with('zmeeting1', expected)
+
+
+@pytest.mark.parametrize('meeting_type', ('regular', 'webinar'))
+def test_update_data_vc_room_pushes_approval_type_before_sync(
+    create_event, create_zoom_meeting, zoom_plugin, zoom_api, meeting_type,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['meeting_type'] = meeting_type
+    vc_room.data['auto_register'] = False
+
+    is_webinar = meeting_type == 'webinar'
+    api_mock = zoom_api['update_webinar' if is_webinar else 'update_meeting']
+    other_mock = zoom_api['update_meeting' if is_webinar else 'update_webinar']
+    api_mock.reset_mock()
+    other_mock.reset_mock()
+
+    zoom_plugin.update_data_vc_room(vc_room, {'auto_register': True})
+
+    api_mock.assert_called_once_with('zmeeting1', {'settings': {'approval_type': 0}})
+    other_mock.assert_not_called()


### PR DESCRIPTION
This PR fixes a bug in Zoom registration:

**Before:** toggling `auto_register` on an existing room never pushed `settings.approval_type` to Zoom, so the meeting kept `approval_type=2` (registration disabled). The first registrant sync then failed with `Registration has not been enabled for this meeting`.

**After:** both `update_room` and `update_data_vc_room` now push `approval_type` (`0` when `auto_register` is on, `2` when off) before syncing registrants, so the initial backfill succeeds.

This PR also:
- Disables the `auto_register` toggle (with help text) when the linked event has already started, since Zoom silently drops `approval_type` on type=3/9 meetings without a future start time.
- Blocks room creation with `auto_register=True` on past events.
- Re-fetches the meeting after PATCH and flashes a warning if Zoom dropped the value.