### PR TITLE
VC/Zoom: Increase videoconference name limit to 200 characters

### DIFF
--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -9,7 +9,7 @@ from flask import session
 from flask_pluginengine import current_plugin
 from wtforms.fields import BooleanField, StringField
 from wtforms.fields.simple import TextAreaField
-from wtforms.validators import DataRequired, ValidationError
+from wtforms.validators import DataRequired, Length, ValidationError
 
 from indico.modules.vc.forms import VCRoomAttachFormBase, VCRoomFormBase
 from indico.util.date_time import now_utc
@@ -64,6 +64,10 @@ class VCRoomForm(VCRoomFormBase):
     ]
 
     skip_fields = set(advanced_fields) | VCRoomFormBase.conditional_fields
+
+    # Override the core 60-char cap: Zoom's meeting/webinar `topic` accepts up to 200.
+    name = StringField(_('Name'), [DataRequired(), Length(min=3, max=200)],
+                       description=_('The name of the videoconference.'))
 
     meeting_type = IndicoRadioField(_('Meeting Type'),
                                     description=_('The type of Zoom meeting to be created'),

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -67,7 +67,7 @@ class VCRoomForm(VCRoomFormBase):
 
     # Override the core 60-char cap: Zoom's meeting/webinar `topic` accepts up to 200.
     name = StringField(_('Name'), [DataRequired(), Length(min=3, max=200)],
-                       description=_('The name of the videoconference.'))
+                       description=_('The name of the Zoom meeting.'))
 
     meeting_type = IndicoRadioField(_('Meeting Type'),
                                     description=_('The type of Zoom meeting to be created'),


### PR DESCRIPTION
The videoconference name was capped at 60 characters, too short for many real meeting titles: customers ran into the limit with standard working-group names. Zoom's own meeting and webinar topic accepts up to 200 characters, so this raises the cap to match. Other videoconference backends keep the existing limit.

Companion to indico/indico#7560, which relaxes the shared 60-character limit in the core so each plugin can set its own service-specific cap.
