### PR TITLE
VC/Zoom: Fix auto-checkin with multiple regforms

### DIFF
--- a/vc_zoom/indico_vc_zoom/controllers.py
+++ b/vc_zoom/indico_vc_zoom/controllers.py
@@ -118,15 +118,17 @@ class RHWebhook(RH):
             if not email:
                 current_plugin.logger.debug('participant_joined with no email for meeting %s', meeting_id)
                 return
-            registration = current_plugin._find_registration_by_participant_email(vc_room, email)
-            if registration is None:
+            registrations = current_plugin._find_registrations_by_participant_email(vc_room, email)
+            if not registrations:
                 current_plugin.logger.debug('No Indico registration for email %s in meeting %s', email, meeting_id)
                 return
-            if registration.checked_in:
-                return
-            registration.checked_in = True
-            signals.event.registration_checkin_updated.send(registration)
-            current_plugin.logger.info('Checked in registration %s via Zoom webhook (meeting %s)',
-                                       registration.id, meeting_id)
+            # The participant may be registered in several of the event's forms; check in all of them.
+            for registration in registrations:
+                if registration.checked_in:
+                    continue
+                registration.checked_in = True
+                signals.event.registration_checkin_updated.send(registration)
+                current_plugin.logger.info('Checked in registration %s via Zoom webhook (meeting %s)',
+                                           registration.id, meeting_id)
         else:
             current_plugin.logger.warning('Unhandled Zoom webhook payload: %s', event)

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -1084,10 +1084,10 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                 self.logger.info(f'Batch-added registrants to Zoom {zoom_type} %s: %s',  # noqa: G004
                                  zoom_id, emails)
 
-    def _find_registration_by_participant_email(self, vc_room, email):
+    def _find_registrations_by_participant_email(self, vc_room, email):
         event_ids = {assoc.event_id for assoc in vc_room.events}
         if not event_ids:
-            return None
+            return []
         candidates = (Registration.query
                       .join(Registration.registration_form)
                       .filter(RegistrationForm.event_id.in_(event_ids),
@@ -1095,7 +1095,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                               ~Registration.is_deleted,
                               ~RegistrationForm.is_deleted))
         email_lower = email.lower()
-        return next((c for c in candidates if self._get_registrant_email(c).lower() == email_lower), None)
+        return [c for c in candidates if self._get_registrant_email(c).lower() == email_lower]
 
     def _remove_registrants(self, client, zoom_id, vc_room, email_ids, is_webinar):
         if not email_ids:

--- a/vc_zoom/tests/webhook_test.py
+++ b/vc_zoom/tests/webhook_test.py
@@ -13,10 +13,25 @@ import time
 import pytest
 
 from indico.core import signals
+from indico.modules.events.registration.models.forms import RegistrationForm
+from indico.modules.events.registration.models.items import RegistrationFormItemType, RegistrationFormSection
+from indico.modules.events.registration.util import create_personal_data_fields
 from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation, VCRoomStatus
 
 
 TOKEN = 'test-webhook-secret'
+
+
+def _add_registration_form(db, event, title):
+    """Attach an extra registration form (with personal-data fields) to an existing event."""
+    regform = RegistrationForm(event=event, title=title, currency='EUR')
+    section = RegistrationFormSection(registration_form=regform, title='Personal Data',
+                                      type=RegistrationFormItemType.section_pd)
+    regform.sections.append(section)
+    create_personal_data_fields(regform)
+    event.registration_forms.append(regform)
+    db.session.flush()
+    return regform
 
 
 @pytest.fixture
@@ -210,6 +225,32 @@ def test_webinar_participant_joined_checks_in_registration(db, zoom_plugin, reg_
     assert resp.status_code == 200
     db.session.refresh(reg)
     assert reg.checked_in
+
+
+@pytest.mark.usefixtures('request_context', 'smtp')
+def test_participant_joined_checks_in_across_two_forms(db, zoom_plugin, reg_form, zoom_user, webhook_client,
+                                                       create_vc_room_with_assoc, make_complete_registration):
+    """A participant registered in two of the event's forms must be checked in on both."""
+    zoom_plugin.settings.set('allow_auto_register', True)
+    event = reg_form.event
+    second_form = _add_registration_form(db, event, 'Second Form')
+    vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=True)
+
+    email = 'test@megacorp.xyz'
+    reg_a = make_complete_registration(reg_form, email, 'Test', 'User')
+    reg_b = make_complete_registration(second_form, email, 'Test', 'User')
+    db.session.flush()
+
+    payload = {
+        'event': 'meeting.participant_joined',
+        'payload': {'object': {'id': str(vc_room.data['zoom_id']), 'participant': {'email': email}}},
+    }
+    resp = webhook_client(payload)
+    assert resp.status_code == 200
+    db.session.refresh(reg_a)
+    db.session.refresh(reg_b)
+    assert reg_a.checked_in
+    assert reg_b.checked_in
 
 
 # ── meeting.deleted tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes automatic check-in for events that have more than one registration form.

When a participant joins a Zoom meeting, the webhook checks them in automatically. A person registered in more than one of the event's forms has a separate registration in each. The handler only checked in one of them and silently left the rest unchecked, so an organizer looking at another form saw the participant as not checked in.

The webhook now checks in every registration that matches the participant across the event's forms, mirroring how automatic registration already pulls registrants from all forms.
