### PR TITLE
VC/Zoom: Resolve registrant emails via a bulk user directory

### DIFF
--- a/vc_zoom/README.md
+++ b/vc_zoom/README.md
@@ -203,6 +203,7 @@ The scopes to select when creating the app are:
 - `meeting:write:batch_registrants:admin` (optional, only needed for automatic registration)
 - `meeting:update:registrant_status:admin` (optional, only needed for automatic registration)
 - `user:read:user:admin`
+- `user:read:list_users:admin` (optional, only needed for automatic registration)
 
 - `webinar:read:webinar:admin` (optional, only needed when using webinars)
 - `webinar:write:webinar:admin` (optional, only needed when using webinars)

--- a/vc_zoom/indico_vc_zoom/api/client.py
+++ b/vc_zoom/indico_vc_zoom/api/client.py
@@ -332,6 +332,9 @@ class ZoomIndicoClient:
             return None
         return _handle_response(resp)
 
+    def list_users(self, **kwargs):
+        return _handle_response(self.client.user.list(**kwargs))
+
 
 def get_zoom_scopes(config):
     """Get the set of OAuth scopes for the given Zoom credentials."""

--- a/vc_zoom/indico_vc_zoom/api/client.py
+++ b/vc_zoom/indico_vc_zoom/api/client.py
@@ -72,6 +72,8 @@ class ZoomSession(Session):
             ZoomPlugin.logger.warning('Request failed with invalid token; getting a new one')
             self.__configure_zoom_api(force=True)
             resp = super().request(method, url, *args, **kwargs)
+        ZoomPlugin.logger.debug('[zoom-api] %s %s params=%s json=%s -> %s', method, url,
+                                kwargs.get('params'), kwargs.get('json'), resp.status_code)
         return resp
 
 

--- a/vc_zoom/indico_vc_zoom/fixtures.py
+++ b/vc_zoom/indico_vc_zoom/fixtures.py
@@ -145,6 +145,9 @@ def zoom_api(zoom_plugin, create_user, mocker):
     api_get_user = mocker.patch('indico_vc_zoom.api.ZoomIndicoClient.get_user')
     api_get_user.return_value = {'id': '7890abcd', 'email': 'don.orange@megacorp.xyz'}
 
+    api_list_users = mocker.patch('indico_vc_zoom.api.ZoomIndicoClient.list_users')
+    api_list_users.return_value = {'users': [{'email': user.email}], 'next_page_token': ''}
+
     def _get_meeting(id_, *args, **kwargs):
         return dict(JSON_DATA, id=id_)
 
@@ -162,6 +165,7 @@ def zoom_api(zoom_plugin, create_user, mocker):
         'update_webinar': api_update_webinar,
         'api_delete_meeting': api_delete_meeting,
         'get_user': api_get_user,
+        'list_users': api_list_users,
     }
 
 

--- a/vc_zoom/indico_vc_zoom/fixtures.py
+++ b/vc_zoom/indico_vc_zoom/fixtures.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 import pytest
+from flask import g
 
 from indico.core.plugins import plugin_engine
 from indico.modules.events.registration.models.forms import RegistrationForm
@@ -18,8 +19,19 @@ from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.events.registration.util import create_personal_data_fields, create_registration
 from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation, VCRoomStatus
 
+from indico_vc_zoom.util import ZOOM_DIRECTORY_CACHE_KEY, _zoom_directory_cache
+
 
 TZ = ZoneInfo('Europe/Zurich')
+
+
+@pytest.fixture
+def zoom_directory_cache():
+    """Isolate the cached Zoom account directory, which outlives a single test."""
+    _zoom_directory_cache.delete(ZOOM_DIRECTORY_CACHE_KEY)
+    g.pop('zoom_account_emails', None)
+    yield _zoom_directory_cache
+    _zoom_directory_cache.delete(ZOOM_DIRECTORY_CACHE_KEY)
 
 
 @pytest.fixture

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -44,7 +44,7 @@ from indico_vc_zoom.notifications import notify_host_start_url
 from indico_vc_zoom.task import refresh_meetings
 from indico_vc_zoom.util import (UserLookupMode, ZoomMeetingType, fetch_zoom_meeting, find_enterprise_email,
                                  gen_random_passcode, get_alt_host_emails, get_schedule_args, get_url_data_args,
-                                 process_alternative_hosts, update_zoom_meeting)
+                                 preload_zoom_account_directory, process_alternative_hosts, update_zoom_meeting)
 
 
 AUTO_REGISTRATION_MEETING_SCOPES = ('meeting:read:list_registrants:admin', 'meeting:write:registrant:admin',
@@ -463,6 +463,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                     if registration.state == RegistrationState.complete
                 ]
                 if candidates:
+                    preload_zoom_account_directory()
                     candidate_emails = {self._get_registrant_email(r) for r in candidates}
                     try:
                         already_registered = set(

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -1012,9 +1012,15 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             email = self._get_registrant_email(registration)
 
             for vc_room in zoom_rooms:
-                if should_add and self._has_other_active_room_registration(vc_room, email, pending_add_ids):
-                    continue
-                if not should_add and self._has_other_active_room_registration(vc_room, email, pending_remove_ids):
+                if should_add:
+                    if self._has_other_active_room_registration(vc_room, email, pending_add_ids):
+                        continue
+                elif remove:
+                    if self._has_other_active_room_registration(vc_room, email, pending_remove_ids):
+                        continue
+                else:
+                    # a freshly created registration that is not complete yet (e.g. pending
+                    # moderation) was never pushed to Zoom, so there is nothing to cancel
                     continue
 
                 zoom_id = vc_room.data['zoom_id']

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -5,9 +5,12 @@
 # them and/or modify them under the terms of the MIT License;
 # see the LICENSE file for more details.
 
+from collections import defaultdict
+
 from flask import after_this_request, flash, g, has_request_context, request, session
 from markupsafe import escape
 from requests.exceptions import HTTPError
+from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.attributes import flag_modified
 from wtforms.fields import BooleanField, IntegerField, TextAreaField, URLField
 from wtforms.fields.simple import StringField
@@ -997,6 +1000,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         pending_remove_ids = {reg.id for reg, remove in pending.values() if remove}
         pending_add_ids = {reg.id for reg, remove in pending.values() if not remove}
         room_ops = {}
+        active_email_index = {}
         for registration, remove in pending.values():
             event = registration.event or registration.registration_form.event
             if event is None:
@@ -1013,10 +1017,10 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
 
             for vc_room in zoom_rooms:
                 if should_add:
-                    if self._has_other_active_room_registration(vc_room, email, pending_add_ids):
+                    if self._has_other_active_room_registration(vc_room, email, pending_add_ids, active_email_index):
                         continue
                 elif remove:
-                    if self._has_other_active_room_registration(vc_room, email, pending_remove_ids):
+                    if self._has_other_active_room_registration(vc_room, email, pending_remove_ids, active_email_index):
                         continue
                 else:
                     # a freshly created registration that is not complete yet (e.g. pending
@@ -1043,10 +1047,14 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             ops['add'] = [e for e in ops['add'].values() if e['data']['email'].lower() not in skip]
         return room_ops
 
-    def _has_other_active_room_registration(self, vc_room, email, exclude_ids):
-        if not (event_ids := {assoc.event_id for assoc in vc_room.events}):
+    def _has_other_active_room_registration(self, vc_room, email, exclude_ids, index):
+        if not (event_ids := frozenset(assoc.event_id for assoc in vc_room.events)):
             return False
+        if event_ids not in index:
+            index[event_ids] = self._build_active_email_index(event_ids)
+        return bool(index[event_ids].get(email, frozenset()) - exclude_ids)
 
+    def _build_active_email_index(self, event_ids):
         query = (Registration.query
                  .join(Registration.registration_form)
                  .join(RegistrationForm.event)
@@ -1054,10 +1062,12 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                          Registration.state == RegistrationState.complete,
                          ~Registration.is_deleted,
                          ~RegistrationForm.is_deleted,
-                         ~Event.is_deleted))
-        if exclude_ids:
-            query = query.filter(Registration.id.notin_(exclude_ids))
-        return any(self._get_registrant_email(registration) == email for registration in query)
+                         ~Event.is_deleted)
+                 .options(joinedload(Registration.user)))
+        index = defaultdict(set)
+        for registration in query:
+            index[self._get_registrant_email(registration)].add(registration.id)
+        return index
 
     @make_interceptable
     def _add_registrants(self, client, zoom_id, registrants, is_webinar):

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -47,10 +47,9 @@ from indico_vc_zoom.cli import cli
 from indico_vc_zoom.forms import VCRoomAttachForm, VCRoomForm
 from indico_vc_zoom.notifications import notify_host_start_url
 from indico_vc_zoom.task import refresh_meetings
-from indico_vc_zoom.util import (DIRECTORY_PRELOAD_THRESHOLD, UserLookupMode, ZoomMeetingType, fetch_zoom_meeting,
-                                 find_enterprise_email, gen_random_passcode, get_alt_host_emails, get_schedule_args,
-                                 get_url_data_args, preload_zoom_account_directory, process_alternative_hosts,
-                                 update_zoom_meeting)
+from indico_vc_zoom.util import (UserLookupMode, ZoomMeetingType, fetch_zoom_meeting, find_enterprise_email,
+                                 gen_random_passcode, get_alt_host_emails, get_schedule_args, get_url_data_args,
+                                 process_alternative_hosts, update_zoom_meeting)
 
 
 AUTO_REGISTRATION_MEETING_SCOPES = ('meeting:read:list_registrants:admin', 'meeting:write:registrant:admin',
@@ -469,8 +468,6 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                     if registration.state == RegistrationState.complete
                 ]
                 if candidates:
-                    if len(candidates) >= DIRECTORY_PRELOAD_THRESHOLD:
-                        self._preload_directory()
                     candidate_emails = {self._get_registrant_email(r) for r in candidates}
                     try:
                         already_registered = set(
@@ -976,20 +973,10 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         pending = g.setdefault('zoom_pending_registrations', {})
         pending[registration.id] = (registration, remove)
 
-    def _preload_directory(self):
-        # Cache the account directory so enterprise-email lookups become local set lookups instead
-        # of one Zoom API call per user; fall back to per-user lookups if it cannot be fetched.
-        try:
-            preload_zoom_account_directory()
-        except HTTPError:
-            self.logger.warning('Could not preload the Zoom account directory; falling back to per-user lookups')
-
     def _flush_pending_registrations(self, sender, **kwargs):
         if not (pending := g.pop('zoom_pending_registrations', None)):
             return
 
-        if len(pending) >= DIRECTORY_PRELOAD_THRESHOLD:
-            self._preload_directory()
         if not (room_ops := self._collect_room_ops(pending)):
             return
 
@@ -1068,8 +1055,6 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                                  ~Event.is_deleted)
                          .options(joinedload(Registration.user))
                          .all())
-        if len(registrations) >= DIRECTORY_PRELOAD_THRESHOLD:
-            self._preload_directory()
         index = defaultdict(set)
         for registration in registrations:
             index[self._get_registrant_email(registration)].add(registration.id)

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -47,9 +47,10 @@ from indico_vc_zoom.cli import cli
 from indico_vc_zoom.forms import VCRoomAttachForm, VCRoomForm
 from indico_vc_zoom.notifications import notify_host_start_url
 from indico_vc_zoom.task import refresh_meetings
-from indico_vc_zoom.util import (UserLookupMode, ZoomMeetingType, fetch_zoom_meeting, find_enterprise_email,
-                                 gen_random_passcode, get_alt_host_emails, get_schedule_args, get_url_data_args,
-                                 preload_zoom_account_directory, process_alternative_hosts, update_zoom_meeting)
+from indico_vc_zoom.util import (DIRECTORY_PRELOAD_THRESHOLD, UserLookupMode, ZoomMeetingType, fetch_zoom_meeting,
+                                 find_enterprise_email, gen_random_passcode, get_alt_host_emails, get_schedule_args,
+                                 get_url_data_args, preload_zoom_account_directory, process_alternative_hosts,
+                                 update_zoom_meeting)
 
 
 AUTO_REGISTRATION_MEETING_SCOPES = ('meeting:read:list_registrants:admin', 'meeting:write:registrant:admin',
@@ -468,7 +469,8 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                     if registration.state == RegistrationState.complete
                 ]
                 if candidates:
-                    self._preload_directory()
+                    if len(candidates) >= DIRECTORY_PRELOAD_THRESHOLD:
+                        self._preload_directory()
                     candidate_emails = {self._get_registrant_email(r) for r in candidates}
                     try:
                         already_registered = set(
@@ -986,7 +988,8 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         if not (pending := g.pop('zoom_pending_registrations', None)):
             return
 
-        self._preload_directory()
+        if len(pending) >= DIRECTORY_PRELOAD_THRESHOLD:
+            self._preload_directory()
         if not (room_ops := self._collect_room_ops(pending)):
             return
 
@@ -1055,17 +1058,20 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         return bool(index[event_ids].get(email, frozenset()) - exclude_ids)
 
     def _build_active_email_index(self, event_ids):
-        query = (Registration.query
-                 .join(Registration.registration_form)
-                 .join(RegistrationForm.event)
-                 .filter(RegistrationForm.event_id.in_(event_ids),
-                         Registration.state == RegistrationState.complete,
-                         ~Registration.is_deleted,
-                         ~RegistrationForm.is_deleted,
-                         ~Event.is_deleted)
-                 .options(joinedload(Registration.user)))
+        registrations = (Registration.query
+                         .join(Registration.registration_form)
+                         .join(RegistrationForm.event)
+                         .filter(RegistrationForm.event_id.in_(event_ids),
+                                 Registration.state == RegistrationState.complete,
+                                 ~Registration.is_deleted,
+                                 ~RegistrationForm.is_deleted,
+                                 ~Event.is_deleted)
+                         .options(joinedload(Registration.user))
+                         .all())
+        if len(registrations) >= DIRECTORY_PRELOAD_THRESHOLD:
+            self._preload_directory()
         index = defaultdict(set)
-        for registration in query:
+        for registration in registrations:
             index[self._get_registrant_email(registration)].add(registration.id)
         return index
 

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -52,10 +52,11 @@ from indico_vc_zoom.util import (UserLookupMode, ZoomMeetingType, fetch_zoom_mee
                                  process_alternative_hosts, update_zoom_meeting)
 
 
+# the user scope backs the account directory registrant emails are resolved against
 AUTO_REGISTRATION_MEETING_SCOPES = ('meeting:read:list_registrants:admin', 'meeting:write:registrant:admin',
                                     'meeting:write:batch_registrants:admin',
-                                    'meeting:update:registrant_status:admin')
-AUTO_REGISTRATION_LEGACY_MEETING_SCOPES = ('meeting:read:admin', 'meeting:write:admin')
+                                    'meeting:update:registrant_status:admin', 'user:read:list_users:admin')
+AUTO_REGISTRATION_LEGACY_MEETING_SCOPES = ('meeting:read:admin', 'meeting:write:admin', 'user:read:admin')
 AUTO_REGISTRATION_WEBINAR_SCOPES = ('webinar:read:list_registrants:admin', 'webinar:write:registrant:admin',
                                     'webinar:write:batch_registrants:admin',
                                     'webinar:update:registrant_status:admin')

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -463,7 +463,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                     if registration.state == RegistrationState.complete
                 ]
                 if candidates:
-                    preload_zoom_account_directory()
+                    self._preload_directory()
                     candidate_emails = {self._get_registrant_email(r) for r in candidates}
                     try:
                         already_registered = set(
@@ -969,10 +969,19 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         pending = g.setdefault('zoom_pending_registrations', {})
         pending[registration.id] = (registration, remove)
 
+    def _preload_directory(self):
+        # Cache the account directory so enterprise-email lookups become local set lookups instead
+        # of one Zoom API call per user; fall back to per-user lookups if it cannot be fetched.
+        try:
+            preload_zoom_account_directory()
+        except HTTPError:
+            self.logger.warning('Could not preload the Zoom account directory; falling back to per-user lookups')
+
     def _flush_pending_registrations(self, sender, **kwargs):
         if not (pending := g.pop('zoom_pending_registrations', None)):
             return
 
+        self._preload_directory()
         if not (room_ops := self._collect_room_ops(pending)):
             return
 
@@ -1095,6 +1104,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                               Registration.state.in_([RegistrationState.complete, RegistrationState.unpaid]),
                               ~Registration.is_deleted,
                               ~RegistrationForm.is_deleted))
+        self._preload_directory()
         email_lower = email.lower()
         return [c for c in candidates if self._get_registrant_email(c).lower() == email_lower]
 

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -18,11 +18,13 @@ from indico.core.auth import multipass
 from indico.core.db import db
 from indico.core.errors import UserValueError
 from indico.core.plugins import IndicoPlugin, render_plugin_template, url_for_plugin
+from indico.modules.auth.models.identities import Identity
 from indico.modules.events.models.events import Event
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.registrations import Registration, RegistrationState
 from indico.modules.events.views import WPConferenceDisplay, WPSimpleEventDisplay
 from indico.modules.logs import EventLogRealm, LogKind
+from indico.modules.users.util import get_user_by_email
 from indico.modules.vc import VCPluginMixin, VCPluginSettingsFormBase
 from indico.modules.vc.exceptions import VCRoomError, VCRoomNotFoundError
 from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomStatus
@@ -1098,15 +1100,32 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         event_ids = {assoc.event_id for assoc in vc_room.events}
         if not event_ids:
             return []
-        candidates = (Registration.query
-                      .join(Registration.registration_form)
-                      .filter(RegistrationForm.event_id.in_(event_ids),
-                              Registration.state.in_([RegistrationState.complete, RegistrationState.unpaid]),
-                              ~Registration.is_deleted,
-                              ~RegistrationForm.is_deleted))
-        self._preload_directory()
-        email_lower = email.lower()
-        return [c for c in candidates if self._get_registrant_email(c).lower() == email_lower]
+        email = email.lower()
+        conditions = [Registration.email == email]
+        if user_ids := [u.id for u in self._users_for_zoom_email(email)]:
+            conditions.append(Registration.user_id.in_(user_ids))
+        return (Registration.query
+                .join(Registration.registration_form)
+                .filter(RegistrationForm.event_id.in_(event_ids),
+                        Registration.state.in_([RegistrationState.complete, RegistrationState.unpaid]),
+                        ~Registration.is_deleted,
+                        ~RegistrationForm.is_deleted,
+                        db.or_(*conditions))
+                .all())
+
+    def _users_for_zoom_email(self, email):
+        users = set()
+        if (user := get_user_by_email(email)) is not None:
+            users.add(user)
+        if self.settings.get('user_lookup_mode') == UserLookupMode.authenticators:
+            domain = self.settings.get('enterprise_domain')
+            providers = self.settings.get('authenticators')
+            if providers and domain and email.endswith(f'@{domain}'):
+                username = email.split('@')[0]
+                users.update(identity.user for identity
+                             in Identity.query.filter(Identity.provider.in_(providers),
+                                                      Identity.identifier == username))
+        return users
 
     def _remove_registrants(self, client, zoom_id, vc_room, email_ids, is_webinar):
         if not email_ids:

--- a/vc_zoom/indico_vc_zoom/task.py
+++ b/vc_zoom/indico_vc_zoom/task.py
@@ -15,6 +15,7 @@ from indico.core.celery import celery
 from indico.core.db import db
 
 from indico_vc_zoom.api.client import get_zoom_token
+from indico_vc_zoom.util import refresh_zoom_account_directory
 
 
 def update_state_log(log_entry, failed):
@@ -62,3 +63,14 @@ def refresh_token(threshold=600):
 
     ZoomPlugin.logger.info('Token expires in %ds, getting a new one', expires_in)
     get_zoom_token(config, force=True)
+
+
+@celery.periodic_task(run_every=crontab(minute='0', hour='3'), plugin='vc_zoom', autoretry_for=(HTTPError,))
+def refresh_account_directory():
+    from indico_vc_zoom.plugin import ZoomPlugin
+
+    if not ZoomPlugin.settings.get('allow_auto_register'):
+        return
+
+    emails = refresh_zoom_account_directory()
+    ZoomPlugin.logger.info('Cached %d Zoom account emails', len(emails))

--- a/vc_zoom/indico_vc_zoom/util.py
+++ b/vc_zoom/indico_vc_zoom/util.py
@@ -10,6 +10,7 @@ import re
 import secrets
 import string
 
+from flask import g
 from requests.exceptions import HTTPError
 
 from indico.core.db import db
@@ -96,9 +97,35 @@ def iter_user_emails(user):
             yield f'{username}@{domain}'
 
 
+# List Users returns up to 2000 per page.
+# See https://developers.zoom.us/docs/api/users/#tag/users/get/users
+LIST_USERS_MAX_PAGE_SIZE = 2000
+
+
+def _iter_zoom_account_emails(client):
+    params = {'page_size': LIST_USERS_MAX_PAGE_SIZE, 'status': 'active'}
+    while True:
+        resp = client.list_users(**params)
+        for user in resp.get('users', []):
+            if email := user.get('email'):
+                yield email.lower()
+        if not (token := resp.get('next_page_token')):
+            break
+        params['next_page_token'] = token
+
+
+def preload_zoom_account_directory():
+    """Cache the Zoom account directory on ``g`` so bulk syncs resolve emails locally."""
+    if 'zoom_account_emails' not in g:
+        g.zoom_account_emails = set(_iter_zoom_account_emails(ZoomIndicoClient()))
+    return g.zoom_account_emails
+
+
 @memoize_request
 def find_enterprise_email(user):
     """Get the email address of a user that has a zoom account."""
+    if (directory := g.get('zoom_account_emails')) is not None:
+        return next((email for email in iter_user_emails(user) if email.lower() in directory), None)
     client = ZoomIndicoClient()
     return next((email for email in iter_user_emails(user) if client.get_user(email, silent=True)), None)
 

--- a/vc_zoom/indico_vc_zoom/util.py
+++ b/vc_zoom/indico_vc_zoom/util.py
@@ -9,10 +9,12 @@ import itertools
 import re
 import secrets
 import string
+from datetime import timedelta
 
 from flask import g
 from requests.exceptions import HTTPError
 
+from indico.core.cache import make_scoped_cache
 from indico.core.db import db
 from indico.modules.auth.models.identities import Identity
 from indico.modules.users.models.emails import UserEmail
@@ -101,6 +103,10 @@ def iter_user_emails(user):
 # See https://developers.zoom.us/docs/api/users/#tag/users/get/users
 LIST_USERS_MAX_PAGE_SIZE = 2000
 
+_zoom_directory_cache = make_scoped_cache('vc-zoom')
+# How long the account email directory is reused before it is fetched from Zoom again.
+ZOOM_DIRECTORY_CACHE_TTL = timedelta(minutes=10)
+
 
 def _iter_zoom_account_emails(client):
     params = {'page_size': LIST_USERS_MAX_PAGE_SIZE, 'status': 'active'}
@@ -115,9 +121,13 @@ def _iter_zoom_account_emails(client):
 
 
 def preload_zoom_account_directory():
-    """Cache the Zoom account directory on ``g`` so bulk syncs resolve emails locally."""
+    """Cache the Zoom account email directory so bulk syncs resolve emails locally."""
     if 'zoom_account_emails' not in g:
-        g.zoom_account_emails = set(_iter_zoom_account_emails(ZoomIndicoClient()))
+        emails = _zoom_directory_cache.get('account-emails')
+        if emails is None:
+            emails = set(_iter_zoom_account_emails(ZoomIndicoClient()))
+            _zoom_directory_cache.set('account-emails', emails, ZOOM_DIRECTORY_CACHE_TTL)
+        g.zoom_account_emails = emails
     return g.zoom_account_emails
 
 

--- a/vc_zoom/indico_vc_zoom/util.py
+++ b/vc_zoom/indico_vc_zoom/util.py
@@ -103,9 +103,13 @@ def iter_user_emails(user):
 # See https://developers.zoom.us/docs/api/users/#tag/users/get/users
 LIST_USERS_MAX_PAGE_SIZE = 2000
 
+# Only walk the whole account directory when at least this many registrants are resolved in one
+# sync; for fewer, the per-user lookup is cheaper than paging through every Zoom account.
+DIRECTORY_PRELOAD_THRESHOLD = 25
+
 _zoom_directory_cache = make_scoped_cache('vc-zoom')
 # How long the account email directory is reused before it is fetched from Zoom again.
-ZOOM_DIRECTORY_CACHE_TTL = timedelta(minutes=10)
+ZOOM_DIRECTORY_CACHE_TTL = timedelta(hours=1)
 
 
 def _iter_zoom_account_emails(client):

--- a/vc_zoom/indico_vc_zoom/util.py
+++ b/vc_zoom/indico_vc_zoom/util.py
@@ -103,13 +103,11 @@ def iter_user_emails(user):
 # See https://developers.zoom.us/docs/api/users/#tag/users/get/users
 LIST_USERS_MAX_PAGE_SIZE = 2000
 
-# Only walk the whole account directory when at least this many registrants are resolved in one
-# sync; for fewer, the per-user lookup is cheaper than paging through every Zoom account.
-DIRECTORY_PRELOAD_THRESHOLD = 25
-
 _zoom_directory_cache = make_scoped_cache('vc-zoom')
-# How long the account email directory is reused before it is fetched from Zoom again.
-ZOOM_DIRECTORY_CACHE_TTL = timedelta(hours=1)
+ZOOM_DIRECTORY_CACHE_KEY = 'account-emails'
+# Kept well above the refresh interval of the task populating it, so a failed run does not leave
+# the directory unavailable until the next one.
+ZOOM_DIRECTORY_CACHE_TTL = timedelta(days=2)
 
 
 def _iter_zoom_account_emails(client):
@@ -124,24 +122,34 @@ def _iter_zoom_account_emails(client):
         params['next_page_token'] = token
 
 
-def preload_zoom_account_directory():
-    """Cache the Zoom account email directory so bulk syncs resolve emails locally."""
+def refresh_zoom_account_directory():
+    """Fetch the Zoom account email directory and cache it.
+
+    Walking the whole account is far too slow to do while serving a request, so this is meant to
+    be called from a periodic task.
+    """
+    emails = set(_iter_zoom_account_emails(ZoomIndicoClient()))
+    _zoom_directory_cache.set(ZOOM_DIRECTORY_CACHE_KEY, emails, ZOOM_DIRECTORY_CACHE_TTL)
+    return emails
+
+
+def get_zoom_account_directory():
+    """Get the cached Zoom account email directory, or `None` if it has not been cached yet."""
     if 'zoom_account_emails' not in g:
-        emails = _zoom_directory_cache.get('account-emails')
-        if emails is None:
-            emails = set(_iter_zoom_account_emails(ZoomIndicoClient()))
-            _zoom_directory_cache.set('account-emails', emails, ZOOM_DIRECTORY_CACHE_TTL)
-        g.zoom_account_emails = emails
+        g.zoom_account_emails = _zoom_directory_cache.get(ZOOM_DIRECTORY_CACHE_KEY)
     return g.zoom_account_emails
 
 
 @memoize_request
 def find_enterprise_email(user):
     """Get the email address of a user that has a zoom account."""
-    if (directory := g.get('zoom_account_emails')) is not None:
-        return next((email for email in iter_user_emails(user) if email.lower() in directory), None)
+    emails = list(iter_user_emails(user))
+    directory = get_zoom_account_directory()
+    if directory and (email := next((e for e in emails if e.lower() in directory), None)):
+        return email
+    # the directory may be unavailable or predate the Zoom account, so fall back to asking Zoom
     client = ZoomIndicoClient()
-    return next((email for email in iter_user_emails(user) if client.get_user(email, silent=True)), None)
+    return next((email for email in emails if client.get_user(email, silent=True)), None)
 
 
 def gen_random_passcode(length=8):

--- a/vc_zoom/tests/registration_test.py
+++ b/vc_zoom/tests/registration_test.py
@@ -408,6 +408,38 @@ def test_vc_room_created_skips_non_complete_registrations(db, zoom_plugin, zoom_
     zoom_api_registrants['add_meeting_registrant'].assert_not_called()
 
 
+@pytest.mark.usefixtures('smtp')
+def test_pending_registration_created_does_not_cancel(db, zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+                                                      create_vc_room_with_assoc):
+    """A newly created registration still awaiting moderation was never pushed to Zoom, so it must not be cancelled."""
+    event = reg_form.event
+    zoom_plugin.settings.set('allow_auto_register', True)
+    create_vc_room_with_assoc(event, zoom_user, auto_register=True)
+
+    data = {'email': 'pending@example.com', 'first_name': 'Pending', 'last_name': 'User', 'affiliation': 'MegaCorp'}
+    form_data = {f.html_field_name: data[f.personal_data_type.name]
+                 for f in reg_form.active_fields if f.personal_data_type and f.personal_data_type.name in data}
+    form_data['email'] = data['email']
+
+    zoom_plugin.settings.set('allow_auto_register', False)
+    registration = create_registration(reg_form, form_data)
+    db.session.flush()
+    registration.state = RegistrationState.pending
+    db.session.flush()
+
+    zoom_plugin.settings.set('allow_auto_register', True)
+    zoom_api_registrants['add_meeting_registrant'].reset_mock()
+    zoom_api_registrants['list_meeting_registrants'].reset_mock()
+    zoom_api_registrants['update_meeting_registrants_status'].reset_mock()
+
+    signals.event.registration_created.send(registration)
+    zoom_plugin._flush_pending_registrations(None)
+
+    zoom_api_registrants['add_meeting_registrant'].assert_not_called()
+    zoom_api_registrants['list_meeting_registrants'].assert_not_called()
+    zoom_api_registrants['update_meeting_registrants_status'].assert_not_called()
+
+
 @pytest.mark.usefixtures('request_context', 'db', 'smtp')
 def test_enable_auto_register_skips_existing_zoom_registrants(
     zoom_plugin, zoom_api_registrants, reg_form, zoom_user,

--- a/vc_zoom/tests/registration_test.py
+++ b/vc_zoom/tests/registration_test.py
@@ -440,6 +440,28 @@ def test_pending_registration_created_does_not_cancel(db, zoom_plugin, zoom_api_
     zoom_api_registrants['update_meeting_registrants_status'].assert_not_called()
 
 
+@pytest.mark.usefixtures('db', 'smtp')
+def test_collect_room_ops_builds_active_index_once(zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
+                                                   create_vc_room_with_assoc, make_complete_registration, mocker):
+    """The active-registration lookup is built once per flush, not once per pending registration."""
+    event = reg_form.event
+    for i in range(5):
+        make_complete_registration(reg_form, f'user{i}@example.com', 'User', str(i))
+
+    zoom_plugin.settings.set('allow_auto_register', True)
+    vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
+    spy = mocker.spy(zoom_plugin, '_build_active_email_index')
+
+    signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
+    zoom_plugin._flush_pending_registrations(None)
+
+    assert spy.call_count == 1
+    assert zoom_api_registrants['batch_meeting_registrants'].call_count == 1
+    batch_data = zoom_api_registrants['batch_meeting_registrants'].call_args[0][1]
+    batch_emails = {r['email'] for r in batch_data['registrants']}
+    assert batch_emails == {f'user{i}@example.com' for i in range(5)}
+
+
 @pytest.mark.usefixtures('request_context', 'db', 'smtp')
 def test_enable_auto_register_skips_existing_zoom_registrants(
     zoom_plugin, zoom_api_registrants, reg_form, zoom_user,

--- a/vc_zoom/tests/registration_test.py
+++ b/vc_zoom/tests/registration_test.py
@@ -324,6 +324,24 @@ def test_vc_room_created_syncs_existing_registrations(zoom_plugin, zoom_api_regi
 
 
 @pytest.mark.usefixtures('db', 'smtp')
+def test_flush_preloads_account_directory(zoom_plugin, zoom_api, zoom_api_registrants, reg_form, zoom_user,
+                                          create_vc_room_with_assoc, make_complete_registration):
+    event = reg_form.event
+    make_complete_registration(reg_form, 'alice@example.com', 'Alice', 'Smith')
+
+    zoom_plugin.settings.set('allow_auto_register', True)
+    vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
+    zoom_api['list_users'].reset_mock()
+    zoom_api['get_user'].reset_mock()
+
+    signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
+    zoom_plugin._flush_pending_registrations(None)
+
+    assert zoom_api['list_users'].called
+    zoom_api['get_user'].assert_not_called()
+
+
+@pytest.mark.usefixtures('db', 'smtp')
 def test_vc_room_created_auto_register_disabled(zoom_plugin, zoom_api_registrants, reg_form, zoom_user,
                                                 create_vc_room_with_assoc, make_complete_registration):
     """No sync when auto_register is disabled."""
@@ -702,6 +720,9 @@ def test_batch_excludes_host_and_alt_host(
 
     vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
     vc_room.data['alternative_hosts'] = [alt_host.persistent_identifier]
+    zoom_api_registrants['list_users'].return_value = {
+        'users': [{'email': zoom_user.email}, {'email': alt_host.email}], 'next_page_token': ''
+    }
     signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
     zoom_plugin._flush_pending_registrations(None)
 

--- a/vc_zoom/tests/registration_test.py
+++ b/vc_zoom/tests/registration_test.py
@@ -8,7 +8,7 @@
 from datetime import timedelta
 
 import pytest
-from flask import session
+from flask import g, session
 
 from indico.core import signals
 from indico.modules.events.features.util import set_feature_enabled
@@ -18,6 +18,8 @@ from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import RegistrationState
 from indico.modules.events.registration.util import create_personal_data_fields, create_registration
 from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation, VCRoomStatus
+
+from indico_vc_zoom import util
 
 
 def test_registration_sync_meeting(db, zoom_plugin, zoom_api_registrants, reg_form, create_zoom_meeting, test_client,
@@ -333,12 +335,33 @@ def test_flush_preloads_account_directory(zoom_plugin, zoom_api, zoom_api_regist
     vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
     zoom_api['list_users'].reset_mock()
     zoom_api['get_user'].reset_mock()
+    util._zoom_directory_cache.delete('account-emails')
+    g.pop('zoom_account_emails', None)
 
     signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
     zoom_plugin._flush_pending_registrations(None)
 
     assert zoom_api['list_users'].called
     zoom_api['get_user'].assert_not_called()
+
+
+@pytest.mark.usefixtures('db', 'smtp')
+def test_preload_directory_reuses_shared_cache(zoom_plugin, zoom_api, mocker):
+    store = {}
+    mocker.patch.object(util._zoom_directory_cache, 'get', side_effect=store.get)
+    cache_set = mocker.patch.object(util._zoom_directory_cache, 'set',
+                                    side_effect=lambda key, value, timeout=None: store.__setitem__(key, value))
+
+    g.pop('zoom_account_emails', None)
+    util.preload_zoom_account_directory()
+    assert zoom_api['list_users'].called
+    assert cache_set.call_args.args[2] == util.ZOOM_DIRECTORY_CACHE_TTL
+
+    # a later request finds the cache warm and skips the account walk
+    g.pop('zoom_account_emails', None)
+    zoom_api['list_users'].reset_mock()
+    util.preload_zoom_account_directory()
+    zoom_api['list_users'].assert_not_called()
 
 
 @pytest.mark.usefixtures('db', 'smtp')

--- a/vc_zoom/tests/registration_test.py
+++ b/vc_zoom/tests/registration_test.py
@@ -8,7 +8,7 @@
 from datetime import timedelta
 
 import pytest
-from flask import g, session
+from flask import session
 
 from indico.core import signals
 from indico.modules.events.features.util import set_feature_enabled
@@ -18,8 +18,6 @@ from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import RegistrationState
 from indico.modules.events.registration.util import create_personal_data_fields, create_registration
 from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation, VCRoomStatus
-
-from indico_vc_zoom import util
 
 
 def test_registration_sync_meeting(db, zoom_plugin, zoom_api_registrants, reg_form, create_zoom_meeting, test_client,
@@ -325,87 +323,19 @@ def test_vc_room_created_syncs_existing_registrations(zoom_plugin, zoom_api_regi
     assert reg_data['first_name'] == 'John'
 
 
-@pytest.mark.usefixtures('db', 'smtp')
-def test_flush_preloads_account_directory(zoom_plugin, zoom_api, zoom_api_registrants, reg_form, zoom_user,
-                                          create_vc_room_with_assoc, make_complete_registration, mocker):
-    mocker.patch('indico_vc_zoom.plugin.DIRECTORY_PRELOAD_THRESHOLD', 1)
+@pytest.mark.usefixtures('db', 'smtp', 'zoom_directory_cache')
+def test_flush_never_walks_account_directory(zoom_plugin, zoom_api, zoom_api_registrants, reg_form, zoom_user,
+                                             create_vc_room_with_assoc, make_complete_registration):
     event = reg_form.event
     make_complete_registration(reg_form, 'alice@example.com', 'Alice', 'Smith')
 
     zoom_plugin.settings.set('allow_auto_register', True)
     vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
     zoom_api['list_users'].reset_mock()
-    zoom_api['get_user'].reset_mock()
-    util._zoom_directory_cache.delete('account-emails')
-    g.pop('zoom_account_emails', None)
 
     signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
     zoom_plugin._flush_pending_registrations(None)
 
-    assert zoom_api['list_users'].called
-    zoom_api['get_user'].assert_not_called()
-
-
-@pytest.mark.usefixtures('smtp')
-def test_flush_below_threshold_skips_directory(db, zoom_plugin, zoom_api, zoom_api_registrants, reg_form, zoom_user,
-                                               create_user, create_vc_room_with_assoc, make_complete_registration):
-    event = reg_form.event
-    user = create_user(5, email='jane@megacorp.xyz')
-    reg = make_complete_registration(reg_form, 'jane.reg@example.com', 'Jane', 'Doe')
-    reg.user = user
-    db.session.flush()
-
-    zoom_plugin.settings.set('allow_auto_register', True)
-    vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
-    zoom_api['list_users'].reset_mock()
-    zoom_api['get_user'].reset_mock()
-    util._zoom_directory_cache.delete('account-emails')
-    g.pop('zoom_account_emails', None)
-
-    signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
-    zoom_plugin._flush_pending_registrations(None)
-
-    zoom_api['list_users'].assert_not_called()
-    assert zoom_api['get_user'].called
-
-
-@pytest.mark.usefixtures('db', 'smtp')
-def test_large_active_index_preloads_directory(zoom_plugin, zoom_api, zoom_api_registrants, reg_form, zoom_user,
-                                               create_vc_room_with_assoc, make_complete_registration, mocker):
-    mocker.patch('indico_vc_zoom.plugin.DIRECTORY_PRELOAD_THRESHOLD', 3)
-    event = reg_form.event
-    for name in ('a', 'b', 'c'):
-        make_complete_registration(reg_form, f'{name}@example.com', name.upper(), 'User')
-
-    zoom_plugin.settings.set('allow_auto_register', True)
-    create_vc_room_with_assoc(event, zoom_user)
-    zoom_api['list_users'].reset_mock()
-    util._zoom_directory_cache.delete('account-emails')
-    g.pop('zoom_account_emails', None)
-
-    new_reg = make_complete_registration(reg_form, 'd@example.com', 'D', 'User')
-    signals.event.registration_created.send(new_reg)
-    zoom_plugin._flush_pending_registrations(None)
-
-    assert zoom_api['list_users'].called
-
-
-@pytest.mark.usefixtures('db', 'smtp')
-def test_preload_directory_reuses_shared_cache(zoom_plugin, zoom_api, mocker):
-    store = {}
-    mocker.patch.object(util._zoom_directory_cache, 'get', side_effect=store.get)
-    cache_set = mocker.patch.object(util._zoom_directory_cache, 'set',
-                                    side_effect=lambda key, value, timeout=None: store.__setitem__(key, value))
-
-    g.pop('zoom_account_emails', None)
-    util.preload_zoom_account_directory()
-    assert zoom_api['list_users'].called
-    assert cache_set.call_args.args[2] == util.ZOOM_DIRECTORY_CACHE_TTL
-
-    # a later request finds the cache warm and skips the account walk
-    g.pop('zoom_account_emails', None)
-    zoom_api['list_users'].reset_mock()
-    util.preload_zoom_account_directory()
     zoom_api['list_users'].assert_not_called()
 
 

--- a/vc_zoom/tests/registration_test.py
+++ b/vc_zoom/tests/registration_test.py
@@ -327,7 +327,8 @@ def test_vc_room_created_syncs_existing_registrations(zoom_plugin, zoom_api_regi
 
 @pytest.mark.usefixtures('db', 'smtp')
 def test_flush_preloads_account_directory(zoom_plugin, zoom_api, zoom_api_registrants, reg_form, zoom_user,
-                                          create_vc_room_with_assoc, make_complete_registration):
+                                          create_vc_room_with_assoc, make_complete_registration, mocker):
+    mocker.patch('indico_vc_zoom.plugin.DIRECTORY_PRELOAD_THRESHOLD', 1)
     event = reg_form.event
     make_complete_registration(reg_form, 'alice@example.com', 'Alice', 'Smith')
 
@@ -343,6 +344,50 @@ def test_flush_preloads_account_directory(zoom_plugin, zoom_api, zoom_api_regist
 
     assert zoom_api['list_users'].called
     zoom_api['get_user'].assert_not_called()
+
+
+@pytest.mark.usefixtures('smtp')
+def test_flush_below_threshold_skips_directory(db, zoom_plugin, zoom_api, zoom_api_registrants, reg_form, zoom_user,
+                                               create_user, create_vc_room_with_assoc, make_complete_registration):
+    event = reg_form.event
+    user = create_user(5, email='jane@megacorp.xyz')
+    reg = make_complete_registration(reg_form, 'jane.reg@example.com', 'Jane', 'Doe')
+    reg.user = user
+    db.session.flush()
+
+    zoom_plugin.settings.set('allow_auto_register', True)
+    vc_room, assoc = create_vc_room_with_assoc(event, zoom_user)
+    zoom_api['list_users'].reset_mock()
+    zoom_api['get_user'].reset_mock()
+    util._zoom_directory_cache.delete('account-emails')
+    g.pop('zoom_account_emails', None)
+
+    signals.vc.vc_room_created.send(vc_room, event=event, assoc=assoc)
+    zoom_plugin._flush_pending_registrations(None)
+
+    zoom_api['list_users'].assert_not_called()
+    assert zoom_api['get_user'].called
+
+
+@pytest.mark.usefixtures('db', 'smtp')
+def test_large_active_index_preloads_directory(zoom_plugin, zoom_api, zoom_api_registrants, reg_form, zoom_user,
+                                               create_vc_room_with_assoc, make_complete_registration, mocker):
+    mocker.patch('indico_vc_zoom.plugin.DIRECTORY_PRELOAD_THRESHOLD', 3)
+    event = reg_form.event
+    for name in ('a', 'b', 'c'):
+        make_complete_registration(reg_form, f'{name}@example.com', name.upper(), 'User')
+
+    zoom_plugin.settings.set('allow_auto_register', True)
+    create_vc_room_with_assoc(event, zoom_user)
+    zoom_api['list_users'].reset_mock()
+    util._zoom_directory_cache.delete('account-emails')
+    g.pop('zoom_account_emails', None)
+
+    new_reg = make_complete_registration(reg_form, 'd@example.com', 'D', 'User')
+    signals.event.registration_created.send(new_reg)
+    zoom_plugin._flush_pending_registrations(None)
+
+    assert zoom_api['list_users'].called
 
 
 @pytest.mark.usefixtures('db', 'smtp')

--- a/vc_zoom/tests/scope_test.py
+++ b/vc_zoom/tests/scope_test.py
@@ -45,6 +45,14 @@ def test_auto_registration_scope_check_proposes_modern_when_no_overlap():
     assert set(missing) == set(AUTO_REGISTRATION_MEETING_SCOPES)
 
 
+def test_auto_registration_scope_check_requires_list_users_scope():
+    # The account directory lookup needs its own scope, which is easy to miss when only the
+    # registrant scopes were granted.
+    granted = set(AUTO_REGISTRATION_MEETING_SCOPES) - {'user:read:list_users:admin'}
+    missing = _get_missing_auto_registration_scopes(granted, allow_webinars=False)
+    assert missing == ('user:read:list_users:admin',)
+
+
 def test_auto_registration_scope_check_only_reports_actually_missing_scopes():
     # User has all modern meeting scopes except the status update one — only that one should appear
     partial_meeting_scopes = set(AUTO_REGISTRATION_MEETING_SCOPES) - {'meeting:update:registrant_status:admin'}

--- a/vc_zoom/tests/task_test.py
+++ b/vc_zoom/tests/task_test.py
@@ -50,3 +50,27 @@ def test_meeting_reschedule(dummy_event, zoom_client):
         refresh_meetings([room.vc_room for room in dummy_event.vc_room_associations], dummy_event, log_entry)
     assert zoom_client.update_meeting.call_count == 2
     assert log_entry.data['State'] == 'failed'
+
+
+@pytest.mark.usefixtures('db')
+def test_refresh_account_directory(zoom_plugin, zoom_api, zoom_directory_cache):
+    from indico_vc_zoom.task import refresh_account_directory
+    from indico_vc_zoom.util import ZOOM_DIRECTORY_CACHE_KEY
+    zoom_plugin.settings.set('allow_auto_register', True)
+    zoom_api['list_users'].reset_mock()
+
+    refresh_account_directory()
+
+    assert zoom_api['list_users'].called
+    assert zoom_directory_cache.get(ZOOM_DIRECTORY_CACHE_KEY) == {'don.orange@megacorp.xyz'}
+
+
+@pytest.mark.usefixtures('db', 'zoom_directory_cache')
+def test_refresh_account_directory_skipped_without_auto_register(zoom_plugin, zoom_api):
+    from indico_vc_zoom.task import refresh_account_directory
+    zoom_plugin.settings.set('allow_auto_register', False)
+    zoom_api['list_users'].reset_mock()
+
+    refresh_account_directory()
+
+    zoom_api['list_users'].assert_not_called()

--- a/vc_zoom/tests/user_lookup_test.py
+++ b/vc_zoom/tests/user_lookup_test.py
@@ -1,0 +1,46 @@
+# This file is part of the Indico plugins.
+# Copyright (C) 2020 - 2026 CERN and ENEA
+#
+# The Indico plugins are free software; you can redistribute
+# them and/or modify them under the terms of the MIT License;
+# see the LICENSE file for more details.
+
+import pytest
+
+from indico_vc_zoom.util import find_enterprise_email, preload_zoom_account_directory
+
+
+@pytest.fixture
+def zoom_api_list_users(zoom_api, mocker):
+    list_users = mocker.patch('indico_vc_zoom.api.ZoomIndicoClient.list_users')
+    list_users.side_effect = [
+        {'users': [{'email': 'Alice@MegaCorp.xyz'}, {'email': 'bob@megacorp.xyz'}], 'next_page_token': 'page-2'},
+        {'users': [{'email': 'carol@megacorp.xyz'}], 'next_page_token': ''},
+    ]
+    return list_users
+
+
+@pytest.mark.usefixtures('request_context', 'db')
+def test_preload_zoom_account_directory_pages_list_users(zoom_api, zoom_api_list_users):
+    directory = preload_zoom_account_directory()
+
+    assert directory == {'alice@megacorp.xyz', 'bob@megacorp.xyz', 'carol@megacorp.xyz'}
+    assert zoom_api_list_users.call_count == 2
+    zoom_api['get_user'].assert_not_called()
+
+
+@pytest.mark.usefixtures('request_context', 'db')
+def test_find_enterprise_email_resolves_against_directory(zoom_api, zoom_api_list_users, create_user):
+    user = create_user(2, email='alice@megacorp.xyz')
+    preload_zoom_account_directory()
+
+    assert find_enterprise_email(user) == 'alice@megacorp.xyz'
+    zoom_api['get_user'].assert_not_called()
+
+
+@pytest.mark.usefixtures('request_context', 'db')
+def test_find_enterprise_email_probes_zoom_without_directory(zoom_api, create_user):
+    user = create_user(2, email='alice@megacorp.xyz')
+
+    assert find_enterprise_email(user) == 'alice@megacorp.xyz'
+    assert zoom_api['get_user'].called

--- a/vc_zoom/tests/user_lookup_test.py
+++ b/vc_zoom/tests/user_lookup_test.py
@@ -7,7 +7,7 @@
 
 import pytest
 
-from indico_vc_zoom.util import find_enterprise_email, preload_zoom_account_directory
+from indico_vc_zoom.util import find_enterprise_email, refresh_zoom_account_directory
 
 
 @pytest.fixture
@@ -20,27 +20,36 @@ def zoom_api_list_users(zoom_api, mocker):
     return list_users
 
 
-@pytest.mark.usefixtures('request_context', 'db')
-def test_preload_zoom_account_directory_pages_list_users(zoom_api, zoom_api_list_users):
-    directory = preload_zoom_account_directory()
+@pytest.mark.usefixtures('request_context', 'db', 'zoom_directory_cache')
+def test_refresh_zoom_account_directory_pages_list_users(zoom_api, zoom_api_list_users):
+    directory = refresh_zoom_account_directory()
 
     assert directory == {'alice@megacorp.xyz', 'bob@megacorp.xyz', 'carol@megacorp.xyz'}
     assert zoom_api_list_users.call_count == 2
     zoom_api['get_user'].assert_not_called()
 
 
-@pytest.mark.usefixtures('request_context', 'db')
+@pytest.mark.usefixtures('request_context', 'db', 'zoom_directory_cache')
 def test_find_enterprise_email_resolves_against_directory(zoom_api, zoom_api_list_users, create_user):
     user = create_user(2, email='alice@megacorp.xyz')
-    preload_zoom_account_directory()
+    refresh_zoom_account_directory()
 
     assert find_enterprise_email(user) == 'alice@megacorp.xyz'
     zoom_api['get_user'].assert_not_called()
 
 
-@pytest.mark.usefixtures('request_context', 'db')
+@pytest.mark.usefixtures('request_context', 'db', 'zoom_directory_cache')
 def test_find_enterprise_email_probes_zoom_without_directory(zoom_api, create_user):
     user = create_user(2, email='alice@megacorp.xyz')
 
     assert find_enterprise_email(user) == 'alice@megacorp.xyz'
+    assert zoom_api['get_user'].called
+
+
+@pytest.mark.usefixtures('request_context', 'db', 'zoom_directory_cache')
+def test_find_enterprise_email_probes_zoom_on_directory_miss(zoom_api, zoom_api_list_users, create_user):
+    user = create_user(2, email='dave@megacorp.xyz')
+    refresh_zoom_account_directory()
+
+    assert find_enterprise_email(user) == 'dave@megacorp.xyz'
     assert zoom_api['get_user'].called

--- a/vc_zoom/tests/webhook_test.py
+++ b/vc_zoom/tests/webhook_test.py
@@ -13,6 +13,7 @@ import time
 import pytest
 
 from indico.core import signals
+from indico.modules.auth.models.identities import Identity
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.items import RegistrationFormItemType, RegistrationFormSection
 from indico.modules.events.registration.util import create_personal_data_fields
@@ -96,6 +97,56 @@ def test_participant_joined_checks_in_registration(db, zoom_plugin, reg_form, zo
     db.session.refresh(reg)
     assert reg.checked_in
     assert reg.checked_in_dt is not None
+
+
+@pytest.mark.usefixtures('request_context', 'smtp')
+def test_participant_joined_checks_in_via_account_email(db, zoom_plugin, reg_form, zoom_user, webhook_client,
+                                                        create_user, create_vc_room_with_assoc,
+                                                        make_complete_registration):
+    zoom_plugin.settings.set('allow_auto_register', True)
+    event = reg_form.event
+    vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=True)
+
+    user = create_user(9, email='jane@megacorp.xyz')
+    reg = make_complete_registration(reg_form, 'jane.typed@example.com', 'Jane', 'Doe')
+    reg.user = user
+    db.session.flush()
+
+    payload = {
+        'event': 'meeting.participant_joined',
+        'payload': {'object': {'id': str(vc_room.data['zoom_id']), 'participant': {'email': 'jane@megacorp.xyz'}}},
+    }
+    resp = webhook_client(payload)
+    assert resp.status_code == 200
+    db.session.refresh(reg)
+    assert reg.checked_in
+
+
+@pytest.mark.usefixtures('request_context', 'smtp')
+def test_participant_joined_checks_in_via_authenticator_identity(db, zoom_plugin, reg_form, zoom_user, webhook_client,
+                                                                 create_user, create_vc_room_with_assoc,
+                                                                 make_complete_registration):
+    zoom_plugin.settings.set('allow_auto_register', True)
+    zoom_plugin.settings.set('user_lookup_mode', 'authenticators')
+    zoom_plugin.settings.set('enterprise_domain', 'megacorp.xyz')
+    zoom_plugin.settings.set('authenticators', ['test-idp'])
+    event = reg_form.event
+    vc_room, _assoc = create_vc_room_with_assoc(event, zoom_user, auto_register=True, auto_checkin=True)
+
+    user = create_user(9, email='jsmith.personal@example.com')
+    db.session.add(Identity(user=user, provider='test-idp', identifier='jsmith', multipass_data={}))
+    reg = make_complete_registration(reg_form, 'jsmith.reg@example.com', 'John', 'Smith')
+    reg.user = user
+    db.session.flush()
+
+    payload = {
+        'event': 'meeting.participant_joined',
+        'payload': {'object': {'id': str(vc_room.data['zoom_id']), 'participant': {'email': 'jsmith@megacorp.xyz'}}},
+    }
+    resp = webhook_client(payload)
+    assert resp.status_code == 200
+    db.session.refresh(reg)
+    assert reg.checked_in
 
 
 @pytest.mark.usefixtures('request_context', 'smtp')


### PR DESCRIPTION
When automatic registration is enabled on an event, resolving each registrant's Zoom-account email used to trigger its own `get_user` call. On an event with hundreds or thousands of registrants that meant one Zoom API call per person on every registration and approval, and once per participant on check-in.

This PR removes that per-registrant call on both fronts:

- **Bulk sync paths** (pushing registrants when the setting is turned on, and syncing on registration or approval) resolve everyone against a cached account user directory instead of asking Zoom per registrant. A daily background task walks the account once through List Users and caches the result, so no request ever pays for that walk. When the directory has not been cached yet, or a registrant is not in it, the lookup falls back to the per-user query.
- **Participant check-in** is resolved with a single indexed database lookup. Zoom already gives us the participant's exact email, so the matching registration is found directly (by registration email, account email, or identity, depending on the configured user lookup mode) with no Zoom call, keeping the webhook well within Zoom's response window.

On those same bulk paths, the check that decides whether a registrant is already covered by another active registration also used to run one database query per registrant. It now builds the set of active registrations for the event once per sync and reuses it, so a sync of thousands of registrants issues a single query instead of one per person.

It also fixes a related correctness issue on the sync path: a registration created while still awaiting moderation is no longer cancelled in Zoom. Only completed registrations are ever added to a meeting, so a pending one has nothing to cancel; the queued sync is now a no-op for it instead of issuing a cancellation that reached the registrant as a spurious cancellation notice.

Outgoing Zoom API requests are also logged at debug level, so the exact sequence of calls a registration or approval triggers can be traced when diagnosing a slow or misbehaving event.

Note: the directory lookup needs the `user:read:list_users:admin` scope, which is now part of the scope check that guards automatic registration.
