### PR TITLE
vc_zoom: inject JS/CSS bundle on timetable pages (fixes #330)

### DIFF
--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -21,6 +21,7 @@ from indico.core.plugins import IndicoPlugin, render_plugin_template, url_for_pl
 from indico.modules.events.models.events import Event
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.registrations import Registration, RegistrationState
+from indico.modules.events.timetable.views import WPDisplayTimetable, WPManageTimetable
 from indico.modules.events.views import WPConferenceDisplay, WPSimpleEventDisplay
 from indico.modules.logs import EventLogRealm, LogKind
 from indico.modules.vc import VCPluginMixin, VCPluginSettingsFormBase
@@ -271,7 +272,8 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         self.connect(signals.core.after_process, self._flush_pending_registrations)
         self.template_hook('event-vc-room-list-item-labels', self._render_vc_room_labels)
         self.template_hook('before-render-registration-info', self._render_registration_zoom_link)
-        for wp in (WPSimpleEventDisplay, WPVCEventPage, WPVCManageEvent, WPConferenceDisplay):
+        for wp in (WPSimpleEventDisplay, WPVCEventPage, WPVCManageEvent, WPConferenceDisplay,
+                   WPDisplayTimetable, WPManageTimetable):
             self.inject_bundle('main.js', wp)
             self.inject_bundle('main.css', wp)
 


### PR DESCRIPTION
Fixes #330.

### What this does

Adds `WPDisplayTimetable` and `WPManageTimetable` to the tuple of page classes that receive the Zoom plugin's `main.js`/`main.css` bundle in `ZoomPlugin.init()`. Minimal diff: one new import, two new entries in the existing tuple.

### Why

Core Indico's timetable balloon template calls `template_hook('vc-actions', ...)` unconditionally (`indico/modules/events/timetable/templates/display/indico/_contribution.html`), and `indico/modules/vc/__init__.py`'s `_inject_vc_room_action_buttons()` renders the VC plugin's join-button partial there whenever a timetable entry has a linked, visible VC room — independent of any plugin-specific wiring. Since the Zoom plugin didn't inject its bundle on `WPDisplayTimetable`/`WPManageTimetable`, that button rendered without styling or a working click handler on the timetable page.

### Testing

- Verified the underlying bug and this fix in a live deployment: Indico 3.3.12 with `indico-plugin-vc-zoom` 3.3.5, confirmed via an automated check that the timetable balloon renders `<ind-vc-zoom-join-button>` and, after applying the equivalent patch, the JS/CSS bundle loads and the button becomes functional.
- I have **not** run this exact diff (rebased against current `master`) against a live install of current upstream — I only verified it statically against the fetched `master` source (confirmed the target import block and tuple line are unchanged from the version I tested against, and ran `ruff check` against this repo's own `ruff.toml`, which passes with no errors).
- No automated test suite coverage was added or run for this change.

### Disclosure

This fix was developed with the assistance of Claude Code (Anthropic's CLI coding agent). Opening as a draft for your review — happy to adjust scope or approach.