### PR TITLE
VC/Zoom: Define alternative hosts on a meeting

### DIFF
--- a/vc_zoom/README.md
+++ b/vc_zoom/README.md
@@ -14,6 +14,7 @@
 ### 3.3.7
 
 - Allow restricting automatic registration to specific registration forms
+- Allow managing co-hosts via Indico
 
 ### 3.3.6
 

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -16,7 +16,7 @@ from indico.util.date_time import now_utc
 from indico.util.string import is_valid_mail
 from indico.util.user import principal_from_identifier
 from indico.web.forms.base import generated_data
-from indico.web.forms.fields import IndicoRadioField, MultipleItemsField, PrincipalField
+from indico.web.forms.fields import IndicoRadioField, MultipleItemsField, PrincipalField, PrincipalListField
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless, IndicoRegexp
 from indico.web.forms.widgets import SwitchWidget
@@ -81,6 +81,10 @@ class VCRoomForm(VCRoomFormBase):
 
     host_user = PrincipalField(_('User'),
                                [HiddenUnless('host_choice', 'someone_else'), DataRequired()])
+
+    alternative_host_users = PrincipalListField(_('Alternative hosts'),
+                                                description=_('These users can start the meeting in the absence of '
+                                                              'the host. They need a Zoom account as well.'))
 
     password = StringField(_('Passcode'),
                            [DataRequired(), IndicoRegexp(r'^\d{8,10}$')],
@@ -161,6 +165,11 @@ class VCRoomForm(VCRoomFormBase):
             defaults.host_choice = 'myself' if host == session.user else 'someone_else'
             defaults.host_user = None if host == session.user else host
 
+        if defaults.alternative_host_users is None:
+            defaults.alternative_host_users = {principal_from_identifier(ident, require_user_token=False)
+                                               for ident in (defaults.alternative_hosts or [])
+                                               if ident != defaults.host}
+
         allow_webinars = current_plugin.settings.get('allow_webinars')
 
         if allow_webinars:
@@ -221,6 +230,12 @@ class VCRoomForm(VCRoomFormBase):
         if self.host_choice.data == 'someone_else':
             self._check_zoom_user(field.data)
 
+    def validate_alternative_host_users(self, field):
+        for user in (field.data or ()):
+            self._check_zoom_user(user)
+            if user.persistent_identifier == self.host.data:
+                raise ValidationError(_('The meeting host cannot be an alternative host'))
+
     def validate_interpreters(self, field):
         items = field.serialized_data or field.data or []
         for item in items:
@@ -248,3 +263,7 @@ class VCRoomForm(VCRoomFormBase):
             return session.user.persistent_identifier
         else:
             return self.host_user.data.persistent_identifier if self.host_user.data else None
+
+    @generated_data
+    def alternative_hosts(self):
+        return sorted(u.persistent_identifier for u in (self.alternative_host_users.data or ()))

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -260,10 +260,12 @@ class VCRoomForm(VCRoomFormBase):
             self._check_zoom_user(field.data)
 
     def validate_alternative_host_users(self, field):
-        for user in (field.data or ()):
-            self._check_zoom_user(user)
-            if user.persistent_identifier == self.host.data:
-                raise ValidationError(_('The meeting host cannot be an alternative host'))
+        users = field.data or ()
+        # unlike the host field, this one holds several users, so the error has to name them
+        if invalid := sorted(user.full_name for user in users if find_enterprise_email(user) is None):
+            raise ValidationError(_('No Zoom account: {}').format(', '.join(invalid)))
+        if any(user.persistent_identifier == self.host.data for user in users):
+            raise ValidationError(_('The meeting host cannot be an alternative host'))
 
     def validate_interpreters(self, field):
         items = field.serialized_data or field.data or []

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -17,7 +17,7 @@ from indico.util.string import is_valid_mail, natural_sort_key
 from indico.util.user import principal_from_identifier
 from indico.web.forms.base import generated_data
 from indico.web.forms.fields import (IndicoRadioField, IndicoSelectMultipleCheckboxField, MultipleItemsField,
-                                     PrincipalField)
+                                     PrincipalField, PrincipalListField)
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless, IndicoRegexp
 from indico.web.forms.widgets import SwitchWidget
@@ -82,6 +82,10 @@ class VCRoomForm(VCRoomFormBase):
 
     host_user = PrincipalField(_('User'),
                                [HiddenUnless('host_choice', 'someone_else'), DataRequired()])
+
+    alternative_host_users = PrincipalListField(_('Alternative hosts'),
+                                                description=_('These users can start the meeting in the absence of '
+                                                              'the host. They need a Zoom account as well.'))
 
     password = StringField(_('Passcode'),
                            [DataRequired(), IndicoRegexp(r'^\d{8,10}$')],
@@ -169,6 +173,11 @@ class VCRoomForm(VCRoomFormBase):
             defaults.host_choice = 'myself' if host == session.user else 'someone_else'
             defaults.host_user = None if host == session.user else host
 
+        if defaults.alternative_host_users is None:
+            defaults.alternative_host_users = {principal_from_identifier(ident, require_user_token=False)
+                                               for ident in (defaults.alternative_hosts or [])
+                                               if ident != defaults.host}
+
         allow_webinars = current_plugin.settings.get('allow_webinars')
 
         if allow_webinars:
@@ -250,6 +259,12 @@ class VCRoomForm(VCRoomFormBase):
         if self.host_choice.data == 'someone_else':
             self._check_zoom_user(field.data)
 
+    def validate_alternative_host_users(self, field):
+        for user in (field.data or ()):
+            self._check_zoom_user(user)
+            if user.persistent_identifier == self.host.data:
+                raise ValidationError(_('The meeting host cannot be an alternative host'))
+
     def validate_interpreters(self, field):
         items = field.serialized_data or field.data or []
         for item in items:
@@ -284,3 +299,7 @@ class VCRoomForm(VCRoomFormBase):
             return session.user.persistent_identifier
         else:
             return self.host_user.data.persistent_identifier if self.host_user.data else None
+
+    @generated_data
+    def alternative_hosts(self):
+        return sorted(u.persistent_identifier for u in (self.alternative_host_users.data or ()))

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -44,7 +44,7 @@ from indico_vc_zoom.notifications import notify_host_start_url
 from indico_vc_zoom.task import refresh_meetings
 from indico_vc_zoom.util import (UserLookupMode, ZoomMeetingType, fetch_zoom_meeting, find_enterprise_email,
                                  gen_random_passcode, get_alt_host_emails, get_schedule_args, get_url_data_args,
-                                 process_alternative_hosts, update_zoom_meeting)
+                                 process_alternative_hosts, resolve_alternative_hosts, update_zoom_meeting)
 
 
 AUTO_REGISTRATION_MEETING_SCOPES = ('meeting:read:list_registrants:admin', 'meeting:write:registrant:admin',
@@ -65,6 +65,10 @@ AUTO_REGISTRATION_SCOPE_OPTIONS = {
 # Limited to 30 by Zoom API.
 # See https://developers.zoom.us/docs/api/meetings/#tag/invitation--registration/post/meetings/{meetingId}/registrants
 BATCH_REGISTRANTS_MAX = 30
+
+
+def _exclude_host(identifiers, host_identifier):
+    return [ident for ident in identifiers if ident != host_identifier]
 
 
 def _format_zoom_scopes(scopes):
@@ -424,7 +428,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
     def update_data_vc_room(self, vc_room, data, is_new=False):
         auto_register_before = vc_room.data.get('auto_register') if not is_new else None
         super().update_data_vc_room(vc_room, data, is_new=is_new)
-        fields = {'description', 'password', 'auto_register', 'auto_checkin'}
+        fields = {'description', 'password', 'auto_register', 'auto_checkin', 'alternative_hosts'}
 
         # we may end up not getting a meeting_type from the form
         # (i.e. webinars are disabled)
@@ -490,6 +494,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         client = ZoomIndicoClient()
         host = principal_from_identifier(vc_room.data['host'], require_user_token=False)
         host_email = find_enterprise_email(host)
+        alt_host_emails = get_alt_host_emails(vc_room.data.get('alternative_hosts') or [])
 
         # get the object that this booking is linked to
         vc_room_assoc = vc_room.events[0]
@@ -517,7 +522,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                 kwargs['type'] = (ZoomMeetingType.webinar
                                   if scheduling_args
                                   else ZoomMeetingType.recurring_webinar_no_time)
-                settings['alternative_hosts'] = host_email
+                settings['alternative_hosts'] = ','.join(dict.fromkeys([host_email, *alt_host_emails]))
             else:
                 kwargs = {
                     'type': (
@@ -533,6 +538,8 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                     'waiting_room': vc_room.data['waiting_room'],
                     'join_before_host': self.settings.get('join_before_host'),
                 })
+                if alt_host_emails:
+                    settings['alternative_hosts'] = ','.join(alt_host_emails)
                 if vc_room.data.get('auto_register'):
                     # Manual approval (1), not automatic (0): the public Zoom registration page holds
                     # self-registrants in "pending", so a leaked link can't self-approve into the
@@ -561,7 +568,10 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             'zoom_id': meeting_obj['id'],
             'start_url': meeting_obj['start_url'],
             'host': host.persistent_identifier,
-            'alternative_hosts': process_alternative_hosts(meeting_obj['settings'].get('alternative_hosts', '')),
+            'alternative_hosts': _exclude_host(
+                process_alternative_hosts(meeting_obj['settings'].get('alternative_hosts', '')),
+                host.persistent_identifier
+            ),
             'registration_required': meeting_obj['settings'].get('approval_type') != 2,
         })
         vc_room.data.update(get_url_data_args(meeting_obj['join_url']))
@@ -618,10 +628,19 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                 self._build_language_interpretation_settings(vc_room)
             )
 
-        alternative_hosts = process_alternative_hosts(zoom_meeting_settings.get('alternative_hosts', ''))
-        if vc_room.data['alternative_hosts'] != alternative_hosts:
-            new_alt_host_emails = get_alt_host_emails(vc_room.data['alternative_hosts'])
-            changes.setdefault('settings', {})['alternative_hosts'] = ','.join(new_alt_host_emails)
+        host_identifier = vc_room.data['host']
+        alternative_hosts, unknown_alt_host_emails = resolve_alternative_hosts(
+            zoom_meeting_settings.get('alternative_hosts', ''))
+        local_alt_hosts = vc_room.data.get('alternative_hosts') or []
+        if set(local_alt_hosts) != set(_exclude_host(alternative_hosts, host_identifier)):
+            # alternative hosts with no Indico user are not editable here, so keep them
+            new_alt_host_emails = get_alt_host_emails(_exclude_host(local_alt_hosts, host_identifier))
+            if is_webinar:
+                host_email = find_enterprise_email(
+                    principal_from_identifier(host_identifier, require_user_token=False))
+                new_alt_host_emails = [host_email, *new_alt_host_emails]
+            changes.setdefault('settings', {})['alternative_hosts'] = ','.join(
+                dict.fromkeys([*new_alt_host_emails, *unknown_alt_host_emails]))
 
         if not is_webinar:
             if vc_room.data['mute_audio'] != zoom_meeting_settings['mute_upon_entry']:
@@ -679,7 +698,10 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             'mute_audio': zoom_meeting['settings'].get('mute_upon_entry'),
             'mute_participant_video': not zoom_meeting['settings'].get('participant_video'),
             'waiting_room': zoom_meeting['settings'].get('waiting_room'),
-            'alternative_hosts': process_alternative_hosts(zoom_meeting['settings'].get('alternative_hosts')),
+            'alternative_hosts': _exclude_host(
+                process_alternative_hosts(zoom_meeting['settings'].get('alternative_hosts')),
+                vc_room.data['host']
+            ),
             'registration_required': zoom_approval_type != 2,
         })
         vc_room.data.update(get_url_data_args(zoom_meeting['join_url']))
@@ -775,6 +797,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             'interpreters': [],
             'host_choice': 'myself',
             'host_user': None,
+            'alternative_hosts': [],
             'password_visibility': 'logged_in'
         })
         return defaults

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -44,7 +44,7 @@ from indico_vc_zoom.notifications import notify_host_start_url
 from indico_vc_zoom.task import refresh_meetings
 from indico_vc_zoom.util import (UserLookupMode, ZoomMeetingType, fetch_zoom_meeting, find_enterprise_email,
                                  gen_random_passcode, get_alt_host_emails, get_schedule_args, get_url_data_args,
-                                 process_alternative_hosts, update_zoom_meeting)
+                                 process_alternative_hosts, resolve_alternative_hosts, update_zoom_meeting)
 
 
 AUTO_REGISTRATION_MEETING_SCOPES = ('meeting:read:list_registrants:admin', 'meeting:write:registrant:admin',
@@ -65,6 +65,10 @@ AUTO_REGISTRATION_SCOPE_OPTIONS = {
 # Limited to 30 by Zoom API.
 # See https://developers.zoom.us/docs/api/meetings/#tag/invitation--registration/post/meetings/{meetingId}/registrants
 BATCH_REGISTRANTS_MAX = 30
+
+
+def _exclude_host(identifiers, host_identifier):
+    return [ident for ident in identifiers if ident != host_identifier]
 
 
 def _format_zoom_scopes(scopes):
@@ -425,7 +429,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         auto_register_before = vc_room.data.get('auto_register') if not is_new else None
         regform_ids_before = self._get_synced_regform_ids(vc_room) if not is_new else None
         super().update_data_vc_room(vc_room, data, is_new=is_new)
-        fields = {'description', 'password', 'auto_register', 'auto_checkin', 'registration_forms'}
+        fields = {'description', 'password', 'auto_register', 'auto_checkin', 'registration_forms', 'alternative_hosts'}
 
         # we may end up not getting a meeting_type from the form
         # (i.e. webinars are disabled)
@@ -515,6 +519,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         client = ZoomIndicoClient()
         host = principal_from_identifier(vc_room.data['host'], require_user_token=False)
         host_email = find_enterprise_email(host)
+        alt_host_emails = get_alt_host_emails(vc_room.data.get('alternative_hosts') or [])
 
         # get the object that this booking is linked to
         vc_room_assoc = vc_room.events[0]
@@ -542,7 +547,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                 kwargs['type'] = (ZoomMeetingType.webinar
                                   if scheduling_args
                                   else ZoomMeetingType.recurring_webinar_no_time)
-                settings['alternative_hosts'] = host_email
+                settings['alternative_hosts'] = ','.join(dict.fromkeys([host_email, *alt_host_emails]))
             else:
                 kwargs = {
                     'type': (
@@ -558,6 +563,8 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                     'waiting_room': vc_room.data['waiting_room'],
                     'join_before_host': self.settings.get('join_before_host'),
                 })
+                if alt_host_emails:
+                    settings['alternative_hosts'] = ','.join(alt_host_emails)
                 if vc_room.data.get('auto_register'):
                     # Manual approval (1), not automatic (0): the public Zoom registration page holds
                     # self-registrants in "pending", so a leaked link can't self-approve into the
@@ -586,7 +593,10 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             'zoom_id': meeting_obj['id'],
             'start_url': meeting_obj['start_url'],
             'host': host.persistent_identifier,
-            'alternative_hosts': process_alternative_hosts(meeting_obj['settings'].get('alternative_hosts', '')),
+            'alternative_hosts': _exclude_host(
+                process_alternative_hosts(meeting_obj['settings'].get('alternative_hosts', '')),
+                host.persistent_identifier
+            ),
             'registration_required': meeting_obj['settings'].get('approval_type') != 2,
         })
         vc_room.data.update(get_url_data_args(meeting_obj['join_url']))
@@ -643,10 +653,19 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
                 self._build_language_interpretation_settings(vc_room)
             )
 
-        alternative_hosts = process_alternative_hosts(zoom_meeting_settings.get('alternative_hosts', ''))
-        if vc_room.data['alternative_hosts'] != alternative_hosts:
-            new_alt_host_emails = get_alt_host_emails(vc_room.data['alternative_hosts'])
-            changes.setdefault('settings', {})['alternative_hosts'] = ','.join(new_alt_host_emails)
+        host_identifier = vc_room.data['host']
+        alternative_hosts, unknown_alt_host_emails = resolve_alternative_hosts(
+            zoom_meeting_settings.get('alternative_hosts', ''))
+        local_alt_hosts = vc_room.data.get('alternative_hosts') or []
+        if set(local_alt_hosts) != set(_exclude_host(alternative_hosts, host_identifier)):
+            # alternative hosts with no Indico user are not editable here, so keep them
+            new_alt_host_emails = get_alt_host_emails(_exclude_host(local_alt_hosts, host_identifier))
+            if is_webinar:
+                host_email = find_enterprise_email(
+                    principal_from_identifier(host_identifier, require_user_token=False))
+                new_alt_host_emails = [host_email, *new_alt_host_emails]
+            changes.setdefault('settings', {})['alternative_hosts'] = ','.join(
+                dict.fromkeys([*new_alt_host_emails, *unknown_alt_host_emails]))
 
         if not is_webinar:
             if vc_room.data['mute_audio'] != zoom_meeting_settings['mute_upon_entry']:
@@ -704,7 +723,10 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             'mute_audio': zoom_meeting['settings'].get('mute_upon_entry'),
             'mute_participant_video': not zoom_meeting['settings'].get('participant_video'),
             'waiting_room': zoom_meeting['settings'].get('waiting_room'),
-            'alternative_hosts': process_alternative_hosts(zoom_meeting['settings'].get('alternative_hosts')),
+            'alternative_hosts': _exclude_host(
+                process_alternative_hosts(zoom_meeting['settings'].get('alternative_hosts')),
+                vc_room.data['host']
+            ),
             'registration_required': zoom_approval_type != 2,
         })
         vc_room.data.update(get_url_data_args(zoom_meeting['join_url']))
@@ -800,6 +822,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             'interpreters': [],
             'host_choice': 'myself',
             'host_user': None,
+            'alternative_hosts': [],
             'password_visibility': 'logged_in'
         })
         return defaults

--- a/vc_zoom/indico_vc_zoom/util.py
+++ b/vc_zoom/indico_vc_zoom/util.py
@@ -5,7 +5,6 @@
 # them and/or modify them under the terms of the MIT License;
 # see the LICENSE file for more details.
 
-import itertools
 import re
 import secrets
 import string
@@ -184,26 +183,42 @@ def get_url_data_args(url):
     }
 
 
-def process_alternative_hosts(emails):
-    """Convert a comma-concatenated list of alternative host e-mails into a list of identifiers."""
+def _find_alternative_host(email):
+    """Get the Indico user owning an alternative host e-mail, if any."""
     from indico_vc_zoom.plugin import ZoomPlugin
     mode = ZoomPlugin.settings.get('user_lookup_mode')
-    emails = re.findall(r'[^,;]+', emails)
     if mode in (UserLookupMode.all_emails, UserLookupMode.email_domains):
-        users = {get_user_by_email(email) for email in emails}
+        return get_user_by_email(email)
     elif mode == UserLookupMode.authenticators:
-        users = set()
         domain = ZoomPlugin.settings.get('enterprise_domain')
-        usernames = {email.split('@')[0] for email in emails if email.endswith(f'@{domain}')}
         providers = ZoomPlugin.settings.get('authenticators')
-        users = []
-        if providers and usernames:
-            criteria = db.or_(((Identity.provider == provider) & (Identity.identifier == username))
-                              for provider, username in itertools.product(providers, usernames))
-            users = [identity.user for identity in Identity.query.filter(criteria)]
+        if not providers or not email.endswith(f'@{domain}'):
+            return None
+        username = email.split('@')[0]
+        criteria = db.or_((Identity.provider == provider) & (Identity.identifier == username)
+                          for provider in providers)
+        identity = Identity.query.filter(criteria).first()
+        return identity.user if identity else None
     else:
         raise TypeError('invalid mode')
-    return [u.persistent_identifier for u in users if u is not None]
+
+
+def resolve_alternative_hosts(emails):
+    """Split alternative host e-mails into Indico user identifiers and unmatched e-mails."""
+    identifiers, unknown_emails = [], []
+    for email in re.findall(r'[^,;]+', emails or ''):
+        email = email.strip()
+        user = _find_alternative_host(email)
+        if user is None:
+            unknown_emails.append(email)
+        elif user.persistent_identifier not in identifiers:
+            identifiers.append(user.persistent_identifier)
+    return identifiers, unknown_emails
+
+
+def process_alternative_hosts(emails):
+    """Convert a comma-concatenated list of alternative host e-mails into a list of identifiers."""
+    return resolve_alternative_hosts(emails)[0]
 
 
 def get_alt_host_emails(identifiers):

--- a/vc_zoom/indico_vc_zoom/util.py
+++ b/vc_zoom/indico_vc_zoom/util.py
@@ -223,8 +223,10 @@ def process_alternative_hosts(emails):
 
 def get_alt_host_emails(identifiers):
     """Convert a list of identities into a list of enterprise e-mails."""
-    emails = [find_enterprise_email(principal_from_identifier(ident, require_user_token=False))
-              for ident in identifiers]
-    if None in emails:
-        raise VCRoomError(_('Could not find Zoom user for alternative host'))
+    users = [principal_from_identifier(ident, require_user_token=False) for ident in identifiers]
+    emails = [find_enterprise_email(user) for user in users]
+    # this may run outside the form (e.g. when the event is rescheduled), so the error
+    # has to name whoever lost their Zoom account for the manager to know what to remove
+    if invalid := sorted(user.full_name for user, email in zip(users, emails, strict=True) if email is None):
+        raise VCRoomError(_('Alternative hosts without a Zoom account: {}').format(', '.join(invalid)))
     return emails

--- a/vc_zoom/tests/alternative_hosts_test.py
+++ b/vc_zoom/tests/alternative_hosts_test.py
@@ -1,0 +1,228 @@
+# This file is part of the Indico plugins.
+# Copyright (C) 2020 - 2026 CERN and ENEA
+#
+# The Indico plugins are free software; you can redistribute
+# them and/or modify them under the terms of the MIT License;
+# see the LICENSE file for more details.
+
+import json
+from contextlib import contextmanager
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+from flask import session
+
+from indico.web.forms.base import FormDefaults
+
+
+TZ = ZoneInfo('Europe/Zurich')
+
+
+@pytest.fixture
+def alt_host(create_user):
+    return create_user(2, email='ada.lovelace@megacorp.xyz')
+
+
+@pytest.fixture
+def event(create_event, zoom_api):
+    return create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+
+@contextmanager
+def _make_form(zoom_plugin, app, event, vc_room=None, formdata=None, user=None):
+    from indico_vc_zoom.forms import VCRoomForm
+
+    defaults = FormDefaults({
+        'name': 'Test',
+        'password': '12345678',
+        'host_choice': 'myself',
+        'description': '',
+        'meeting_type': 'regular',
+        'linking': 'event',
+        'mute_audio': True,
+        'mute_host_video': True,
+        'mute_participant_video': True,
+        'waiting_room': False,
+        'alternative_hosts': vc_room.data['alternative_hosts'] if vc_room is not None else [],
+        'host': vc_room.data['host'] if vc_room is not None else None,
+    })
+    with app.test_request_context(method='POST', data=formdata), zoom_plugin.plugin_context():
+        if user is not None:
+            session.set_session_user(user)
+        yield VCRoomForm(prefix='vc-', obj=defaults, event=event, vc_room=vc_room)
+
+
+def _zoom_meeting(meeting_id, alternative_hosts):
+    return {
+        'id': meeting_id,
+        'join_url': 'https://example.com/kitties',
+        'start_url': 'https://example.com/puppies',
+        'password': '13371337',
+        'host_id': 'don.orange@megacorp.xyz',
+        'topic': 'Zoom Meeting',
+        'agenda': 'nothing to add',
+        'settings': {
+            'host_video': False,
+            'mute_upon_entry': True,
+            'participant_video': False,
+            'waiting_room': False,
+            'alternative_hosts': alternative_hosts,
+            'approval_type': 2,
+        },
+    }
+
+
+def _patched_alternative_hosts(api_mock):
+    return api_mock.call_args.args[1]['settings']['alternative_hosts']
+
+
+def test_create_room_sends_alternative_hosts(create_zoom_meeting, zoom_plugin, zoom_api, event, alt_host):
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['alternative_hosts'] = [alt_host.persistent_identifier]
+    zoom_api['create_meeting'].reset_mock()
+
+    zoom_plugin.create_room(vc_room, event)
+
+    settings = zoom_api['create_meeting'].call_args.kwargs['settings']
+    assert settings['alternative_hosts'] == 'ada.lovelace@megacorp.xyz'
+
+
+def test_create_room_without_alternative_hosts_omits_setting(create_zoom_meeting, zoom_plugin, zoom_api, event):
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['alternative_hosts'] = []
+    zoom_api['create_meeting'].reset_mock()
+
+    zoom_plugin.create_room(vc_room, event)
+
+    assert 'alternative_hosts' not in zoom_api['create_meeting'].call_args.kwargs['settings']
+
+
+def test_create_webinar_keeps_host_as_alternative_host(mocker, create_zoom_meeting, zoom_plugin, zoom_api, event,
+                                                       alt_host):
+    create_webinar = mocker.patch('indico_vc_zoom.plugin.ZoomIndicoClient.create_webinar')
+    create_webinar.side_effect = zoom_api['create_meeting'].side_effect
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['meeting_type'] = 'webinar'
+    vc_room.data['alternative_hosts'] = [alt_host.persistent_identifier]
+
+    zoom_plugin.create_room(vc_room, event)
+
+    settings = create_webinar.call_args.kwargs['settings']
+    assert settings['alternative_hosts'] == 'don.orange@megacorp.xyz,ada.lovelace@megacorp.xyz'
+
+
+def test_create_webinar_does_not_store_host_as_alternative_host(mocker, create_zoom_meeting, zoom_plugin, zoom_api,
+                                                                event, alt_host):
+    create_webinar = mocker.patch('indico_vc_zoom.plugin.ZoomIndicoClient.create_webinar')
+    create_webinar.side_effect = lambda user_id, **kwargs: _zoom_meeting(123456,
+                                                                        kwargs['settings']['alternative_hosts'])
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['meeting_type'] = 'webinar'
+    vc_room.data['alternative_hosts'] = [alt_host.persistent_identifier]
+
+    zoom_plugin.create_room(vc_room, event)
+
+    assert vc_room.data['alternative_hosts'] == [alt_host.persistent_identifier]
+
+
+def test_update_room_pushes_alternative_hosts(mocker, create_zoom_meeting, zoom_plugin, zoom_api, event, alt_host):
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['alternative_hosts'] = [alt_host.persistent_identifier]
+    mocker.patch('indico_vc_zoom.plugin.ZoomIndicoClient.get_meeting',
+                 side_effect=lambda id_, *a, **kw: _zoom_meeting(id_, ''))
+    api_mock = mocker.patch('indico_vc_zoom.util.ZoomIndicoClient.update_meeting')
+
+    zoom_plugin.update_room(vc_room, event)
+
+    assert _patched_alternative_hosts(api_mock) == 'ada.lovelace@megacorp.xyz'
+
+
+def test_update_room_ignores_alternative_host_order(mocker, create_zoom_meeting, zoom_plugin, zoom_api, event,
+                                                    alt_host, create_user):
+    other = create_user(3, email='alan.turing@megacorp.xyz')
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['alternative_hosts'] = [alt_host.persistent_identifier, other.persistent_identifier]
+    mocker.patch('indico_vc_zoom.plugin.ZoomIndicoClient.get_meeting',
+                 side_effect=lambda id_, *a, **kw: _zoom_meeting(
+                     id_, 'alan.turing@megacorp.xyz,ada.lovelace@megacorp.xyz'))
+    api_mock = mocker.patch('indico_vc_zoom.util.ZoomIndicoClient.update_meeting')
+
+    zoom_plugin.update_room(vc_room, event)
+
+    api_mock.assert_not_called()
+
+
+def test_update_room_keeps_alternative_hosts_without_indico_user(mocker, create_zoom_meeting, zoom_plugin, zoom_api,
+                                                                 event, alt_host):
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['alternative_hosts'] = [alt_host.persistent_identifier]
+    mocker.patch('indico_vc_zoom.plugin.ZoomIndicoClient.get_meeting',
+                 side_effect=lambda id_, *a, **kw: _zoom_meeting(id_, 'av-team@megacorp.xyz'))
+    api_mock = mocker.patch('indico_vc_zoom.util.ZoomIndicoClient.update_meeting')
+
+    zoom_plugin.update_room(vc_room, event)
+
+    assert _patched_alternative_hosts(api_mock) == 'ada.lovelace@megacorp.xyz,av-team@megacorp.xyz'
+
+
+def test_update_room_does_not_wipe_alternative_host_without_indico_user(mocker, create_zoom_meeting, zoom_plugin,
+                                                                        zoom_api, event):
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['alternative_hosts'] = []
+    mocker.patch('indico_vc_zoom.plugin.ZoomIndicoClient.get_meeting',
+                 side_effect=lambda id_, *a, **kw: _zoom_meeting(id_, 'av-team@megacorp.xyz'))
+    api_mock = mocker.patch('indico_vc_zoom.util.ZoomIndicoClient.update_meeting')
+
+    zoom_plugin.update_room(vc_room, event)
+
+    api_mock.assert_not_called()
+
+
+def test_form_stores_alternative_hosts_as_identifiers(zoom_plugin, app, event, zoom_api, zoom_user, alt_host):
+    formdata = {'vc-alternative_host_users': json.dumps([alt_host.identifier])}
+
+    with _make_form(zoom_plugin, app, event, formdata=formdata, user=zoom_user) as form:
+        assert form.data['alternative_hosts'] == [alt_host.persistent_identifier]
+
+
+def test_form_rejects_alternative_host_without_zoom_account(zoom_plugin, app, no_csrf_check, event, zoom_api,
+                                                            zoom_user, create_user):
+    outsider = create_user(4, email='grace.hopper@example.com')
+    formdata = {'vc-alternative_host_users': json.dumps([outsider.identifier])}
+
+    with _make_form(zoom_plugin, app, event, formdata=formdata, user=zoom_user) as form:
+        assert not form.validate()
+        assert 'no Zoom account' in str(form.alternative_host_users.errors[0])
+
+
+def test_form_rejects_host_as_alternative_host(zoom_plugin, app, no_csrf_check, event, zoom_api, zoom_user):
+    formdata = {'vc-alternative_host_users': json.dumps([zoom_user.identifier])}
+
+    with _make_form(zoom_plugin, app, event, formdata=formdata, user=zoom_user) as form:
+        assert not form.validate()
+        assert 'cannot be an alternative host' in str(form.alternative_host_users.errors[0])
+
+
+def test_form_omits_host_from_alternative_hosts_when_editing(zoom_plugin, app, create_zoom_meeting, event, zoom_api,
+                                                             alt_host, zoom_user):
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['alternative_hosts'] = [zoom_user.persistent_identifier, alt_host.persistent_identifier]
+
+    with _make_form(zoom_plugin, app, event, vc_room=vc_room) as form:
+        assert form.alternative_host_users.data == {alt_host}
+
+
+def test_form_prefills_alternative_hosts_when_editing(zoom_plugin, app, create_zoom_meeting, event, zoom_api,
+                                                      alt_host):
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['alternative_hosts'] = [alt_host.persistent_identifier]
+
+    with _make_form(zoom_plugin, app, event, vc_room=vc_room) as form:
+        assert form.alternative_host_users.data == {alt_host}

--- a/vc_zoom/tests/alternative_hosts_test.py
+++ b/vc_zoom/tests/alternative_hosts_test.py
@@ -13,6 +13,7 @@ from zoneinfo import ZoneInfo
 import pytest
 from flask import session
 
+from indico.modules.vc.exceptions import VCRoomError
 from indico.web.forms.base import FormDefaults
 
 
@@ -21,7 +22,15 @@ TZ = ZoneInfo('Europe/Zurich')
 
 @pytest.fixture
 def alt_host(create_user):
-    return create_user(2, email='ada.lovelace@megacorp.xyz')
+    return create_user(2, first_name='Ada', last_name='Lovelace', email='ada.lovelace@megacorp.xyz')
+
+
+@pytest.fixture
+def alt_host_gone_from_zoom(zoom_api, alt_host):
+    zoom_api['get_user'].side_effect = (
+        lambda email, *args, **kwargs: None if email == alt_host.email else {'id': '7890abcd', 'email': email}
+    )
+    return alt_host
 
 
 @pytest.fixture
@@ -194,12 +203,25 @@ def test_form_stores_alternative_hosts_as_identifiers(zoom_plugin, app, event, z
 
 def test_form_rejects_alternative_host_without_zoom_account(zoom_plugin, app, no_csrf_check, event, zoom_api,
                                                             zoom_user, create_user):
-    outsider = create_user(4, email='grace.hopper@example.com')
+    outsider = create_user(4, first_name='Grace', last_name='Hopper', email='grace.hopper@example.com')
     formdata = {'vc-alternative_host_users': json.dumps([outsider.identifier])}
 
     with _make_form(zoom_plugin, app, event, formdata=formdata, user=zoom_user) as form:
         assert not form.validate()
-        assert 'no Zoom account' in str(form.alternative_host_users.errors[0])
+        assert 'No Zoom account: Grace Hopper' in str(form.alternative_host_users.errors[0])
+
+
+def test_form_names_every_alternative_host_without_zoom_account(zoom_plugin, app, no_csrf_check, event, zoom_api,
+                                                                zoom_user, create_user):
+    outsiders = [create_user(4, first_name='Grace', last_name='Hopper', email='grace.hopper@example.com'),
+                 create_user(5, first_name='Alan', last_name='Turing', email='alan.turing@example.com')]
+    formdata = {'vc-alternative_host_users': json.dumps([u.identifier for u in outsiders])}
+
+    with _make_form(zoom_plugin, app, event, formdata=formdata, user=zoom_user) as form:
+        assert not form.validate()
+        error = str(form.alternative_host_users.errors[0])
+        assert 'Grace Hopper' in error
+        assert 'Alan Turing' in error
 
 
 def test_form_rejects_host_as_alternative_host(zoom_plugin, app, no_csrf_check, event, zoom_api, zoom_user):
@@ -226,3 +248,32 @@ def test_form_prefills_alternative_hosts_when_editing(zoom_plugin, app, create_z
 
     with _make_form(zoom_plugin, app, event, vc_room=vc_room) as form:
         assert form.alternative_host_users.data == {alt_host}
+
+
+def test_form_loads_alternative_host_removed_from_zoom(zoom_plugin, app, create_zoom_meeting, event, zoom_api,
+                                                       alt_host_gone_from_zoom):
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['alternative_hosts'] = [alt_host_gone_from_zoom.persistent_identifier]
+
+    with _make_form(zoom_plugin, app, event, vc_room=vc_room) as form:
+        assert form.alternative_host_users.data == {alt_host_gone_from_zoom}
+
+
+def test_form_rejects_alternative_host_removed_from_zoom(zoom_plugin, app, no_csrf_check, event, zoom_api, zoom_user,
+                                                         alt_host_gone_from_zoom):
+    formdata = {'vc-alternative_host_users': json.dumps([alt_host_gone_from_zoom.identifier])}
+
+    with _make_form(zoom_plugin, app, event, formdata=formdata, user=zoom_user) as form:
+        assert not form.validate()
+        assert 'No Zoom account: Ada Lovelace' in str(form.alternative_host_users.errors[0])
+
+
+def test_update_room_names_alternative_host_removed_from_zoom(mocker, create_zoom_meeting, zoom_plugin, zoom_api, event,
+                                                              alt_host_gone_from_zoom):
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['alternative_hosts'] = [alt_host_gone_from_zoom.persistent_identifier]
+    mocker.patch('indico_vc_zoom.plugin.ZoomIndicoClient.get_meeting',
+                 side_effect=lambda id_, *a, **kw: _zoom_meeting(id_, ''))
+
+    with pytest.raises(VCRoomError, match='Ada Lovelace'):
+        zoom_plugin.update_room(vc_room, event)


### PR DESCRIPTION
This PR lets managers pick alternative hosts when creating or editing a Zoom meeting, so someone other than the host can start it.

Only Indico users with a Zoom account can be selected, and the meeting host cannot be one of them.

<img width="787" height="330" alt="Screenshot 2026-08-10 at 17 07 08" src="https://github.com/user-attachments/assets/2420b881-9ecf-4103-bc32-df3e9c480737" />

