### PR TITLE
VC/Zoom: Let users choose the audio type of a meeting

### DIFF
--- a/vc_zoom/indico_vc_zoom/fixtures.py
+++ b/vc_zoom/indico_vc_zoom/fixtures.py
@@ -89,6 +89,7 @@ def create_zoom_meeting(db, test_client, no_csrf_check, smtp, zoom_api):
                     'vc-mute_host_video': 'y',
                     'vc-mute_audio': 'y',
                     f'vc-{link_type}': obj.id,
+                    **{f'vc-{key}': value for key, value in kwargs.items()},
                 },
             )
             assert resp.status_code == 200
@@ -134,6 +135,9 @@ def zoom_api(zoom_plugin, create_user, mocker):
     api_create_meeting = mocker.patch('indico_vc_zoom.api.ZoomIndicoClient.create_meeting')
     api_create_meeting.side_effect = _create_meeting
 
+    api_create_webinar = mocker.patch('indico_vc_zoom.api.ZoomIndicoClient.create_webinar')
+    api_create_webinar.side_effect = _create_meeting
+
     api_update_meeting = mocker.patch('indico_vc_zoom.api.ZoomIndicoClient.update_meeting')
     api_update_meeting.return_value = {}
 
@@ -157,6 +161,7 @@ def zoom_api(zoom_plugin, create_user, mocker):
     return {
         'user': user,
         'create_meeting': api_create_meeting,
+        'create_webinar': api_create_webinar,
         'get_meeting': api_get_meeting,
         'update_meeting': api_update_meeting,
         'update_webinar': api_update_webinar,

--- a/vc_zoom/indico_vc_zoom/forms.py
+++ b/vc_zoom/indico_vc_zoom/forms.py
@@ -55,6 +55,7 @@ class VCRoomForm(VCRoomFormBase):
     """Contains all information concerning a Zoom booking."""
 
     advanced_fields = [
+        'audio',
         'mute_audio',
         'mute_host_video',
         'mute_participant_video',
@@ -95,6 +96,13 @@ class VCRoomForm(VCRoomFormBase):
                                                ('logged_in', _('Logged-in users')),
                                                ('registered', _('Registered participants')),
                                                ('no_one', _('No one'))])
+
+    audio = IndicoRadioField(_('Audio'),
+                             choices=[
+                                 ('both', _('Telephone and computer audio')),
+                                 ('voip', _('Computer audio')),
+                                 ('telephony', _('Telephone'))],
+                             description=_('How participants can join the audio of the meeting'))
 
     mute_audio = BooleanField(_('Mute audio'),
                               widget=SwitchWidget(),
@@ -156,6 +164,8 @@ class VCRoomForm(VCRoomFormBase):
 
     def __init__(self, *args, **kwargs):
         defaults = kwargs['obj']
+        if defaults.audio is None:
+            defaults.audio = 'both'
         if defaults.host_user is None and defaults.host is not None:
             host = principal_from_identifier(defaults.host, require_user_token=False)
             defaults.host_choice = 'myself' if host == session.user else 'someone_else'

--- a/vc_zoom/indico_vc_zoom/plugin.py
+++ b/vc_zoom/indico_vc_zoom/plugin.py
@@ -424,7 +424,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
     def update_data_vc_room(self, vc_room, data, is_new=False):
         auto_register_before = vc_room.data.get('auto_register') if not is_new else None
         super().update_data_vc_room(vc_room, data, is_new=is_new)
-        fields = {'description', 'password', 'auto_register', 'auto_checkin'}
+        fields = {'description', 'password', 'auto_register', 'auto_checkin', 'audio'}
 
         # we may end up not getting a meeting_type from the form
         # (i.e. webinars are disabled)
@@ -508,6 +508,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
         try:
             settings = {
                 'use_pmi': False,
+                'audio': vc_room.data['audio'],
                 'host_video': not vc_room.data['mute_host_video'],
                 'language_interpretation': self._build_language_interpretation_settings(vc_room)
             }
@@ -595,6 +596,9 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             changes['password'] = vc_room.data['password']
 
         zoom_meeting_settings = zoom_meeting['settings']
+        if vc_room.data['audio'] != zoom_meeting_settings.get('audio'):
+            changes.setdefault('settings', {})['audio'] = vc_room.data['audio']
+
         if vc_room.data['mute_host_video'] == zoom_meeting_settings['host_video']:
             changes.setdefault('settings', {})['host_video'] = not vc_room.data['mute_host_video']
 
@@ -667,6 +671,7 @@ class ZoomPlugin(VCPluginMixin, IndicoPlugin):
             'description': zoom_meeting.get('agenda', ''),
             'zoom_id': zoom_meeting['id'],
             'password': zoom_meeting['password'],
+            'audio': zoom_meeting['settings'].get('audio'),
             'mute_host_video': not zoom_meeting['settings']['host_video'],
             'language_interpretation': zoom_meeting['settings'].get('language_interpretation', {}).get('enable', False),
             'interpreters': [

--- a/vc_zoom/tests/operation_test.py
+++ b/vc_zoom/tests/operation_test.py
@@ -48,6 +48,7 @@ def _aligned_meeting(meeting_id, *, approval_type):
         'topic': 'Zoom Meeting',
         'agenda': 'nothing to add',
         'settings': {
+            'audio': 'both',
             'host_video': False,
             'mute_upon_entry': True,
             'participant_video': False,
@@ -95,6 +96,7 @@ def test_password_change(create_user, mocker, create_event, create_zoom_meeting,
             'topic': 'Zoom Meeting',
             'agenda': 'nothing to add',
             'settings': {
+                'audio': 'both',
                 'host_video': False,
                 'mute_upon_entry': True,
                 'participant_video': False,
@@ -242,6 +244,91 @@ def test_create_room_with_auto_register_uses_manual_approval(
     zoom_api['create_meeting'].assert_called_once()
     settings = zoom_api['create_meeting'].call_args.kwargs['settings']
     assert settings['approval_type'] == 1
+
+
+@pytest.mark.parametrize(('submitted_audio', 'expected'), ((None, 'both'), ('voip', 'voip')))
+def test_create_room_audio_comes_from_the_form(
+    create_event, create_zoom_meeting, zoom_api, submitted_audio, expected,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event', **({'audio': submitted_audio} if submitted_audio else {}))
+
+    assert vc_room.data['audio'] == expected
+    assert zoom_api['create_meeting'].call_args.kwargs['settings']['audio'] == expected
+
+
+@pytest.mark.parametrize(('meeting_type', 'api_method'),
+                         (('regular', 'create_meeting'), ('webinar', 'create_webinar')))
+def test_create_room_sends_audio(
+    create_event, create_zoom_meeting, zoom_plugin, zoom_api, meeting_type, api_method,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['meeting_type'] = meeting_type
+    vc_room.data['audio'] = 'telephony'
+    zoom_api[api_method].reset_mock()
+
+    zoom_plugin.create_room(vc_room, event)
+
+    zoom_api[api_method].assert_called_once()
+    assert zoom_api[api_method].call_args.kwargs['settings']['audio'] == 'telephony'
+
+
+@pytest.mark.parametrize(('is_webinar', 'api_method'),
+                         ((False, 'update_meeting'), (True, 'update_webinar')))
+def test_update_room_pushes_audio_change(
+    mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api, is_webinar, api_method,
+):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+    vc_room.data['audio'] = 'voip'
+    mocker.patch('indico_vc_zoom.plugin.fetch_zoom_meeting',
+                 return_value=(_aligned_meeting(100000, approval_type=2), is_webinar))
+    zoom_api[api_method].reset_mock()
+
+    zoom_plugin.update_room(vc_room, event)
+
+    zoom_api[api_method].assert_called_once_with(100000, {'settings': {'audio': 'voip'}})
+
+
+def test_refresh_room_syncs_audio(mocker, create_event, create_zoom_meeting, zoom_plugin, zoom_api):
+    event = create_event(
+        creator=zoom_api['user'],
+        start_dt=datetime(2024, 3, 1, 16, 0, tzinfo=TZ),
+        end_dt=datetime(2024, 3, 1, 18, 0, tzinfo=TZ),
+        title='Test Event #1',
+        creator_has_privileges=True,
+    )
+
+    vc_room = create_zoom_meeting(event, 'event')
+    zoom_meeting = _aligned_meeting(100000, approval_type=2)
+    zoom_meeting['settings']['audio'] = 'telephony'
+    mocker.patch('indico_vc_zoom.plugin.fetch_zoom_meeting', return_value=(zoom_meeting, False))
+
+    zoom_plugin.refresh_room(vc_room, event)
+
+    assert vc_room.data['audio'] == 'telephony'
 
 
 @pytest.mark.parametrize('is_webinar', (False, True))


### PR DESCRIPTION
This PR adds an `Audio` option to the advanced settings of a Zoom videoconference, so users can choose whether participants join through the telephone, computer audio, or both. New meetings keep whatever Zoom has as its own default, and the value stays in sync when the meeting is edited or refreshed.


<img width="872" height="451" alt="Screenshot 2026-08-11 at 14 21 21" src="https://github.com/user-attachments/assets/3c2ba948-da22-46aa-a1e6-d658b7caf70a" />
