### PR TITLE
URSH: Fail nicely on missing request args

### DIFF
--- a/ursh/README.md
+++ b/ursh/README.md
@@ -13,6 +13,10 @@ human-friendly shortcuts pointing to an event (such as `https://indico.example.c
 
 ## Changelog
 
+### 3.3.5
+
+- Fail gracefully in case of missing request arguments
+
 ### 3.3.4
 
 - Use more accessible dropdown menu in event header

--- a/ursh/indico_ursh/controllers.py
+++ b/ursh/indico_ursh/controllers.py
@@ -8,12 +8,15 @@
 import posixpath
 from urllib.parse import urlsplit, urlunsplit
 
-from flask import jsonify, request, session
+from flask import jsonify, session
 from flask_pluginengine import render_plugin_template
+from marshmallow import fields
 from werkzeug.exceptions import BadRequest, NotFound
 
 from indico.core.config import config
 from indico.modules.events.management.controllers import RHManageEventBase
+from indico.util.marshmallow import not_empty
+from indico.web.args import use_kwargs
 from indico.web.rh import RH
 from indico.web.util import jsonify_template
 
@@ -40,8 +43,10 @@ class RHGetShortURL(RH):
         if urlsplit(full_url).hostname != urlsplit(config.BASE_URL).hostname:
             raise BadRequest('Invalid host for URL shortening service')
 
-    def _process(self):
-        original_url = request.json.get('original_url')
+    @use_kwargs({
+        'original_url': fields.String(required=True, validate=not_empty),
+    })
+    def _process(self, original_url):
         full_url = self._resolve_full_url(original_url)
         self._check_host(full_url)
         short_url = request_short_url(full_url)
@@ -76,8 +81,11 @@ class RHCustomShortURLPage(RHManageEventBase):
         api_host = urlsplit(UrshPlugin.settings.get('api_host'))
         self.ursh_host = strip_end(urlunsplit(api_host), api_host.path[1:]).rstrip('/') + '/'
 
-    def _process_GET(self):
-        original_url = self._make_absolute_url(request.args['original_url'])
+    @use_kwargs({
+        'original_url': fields.String(required=True, validate=not_empty),
+    }, location='query')
+    def _process_GET(self, original_url):
+        original_url = self._make_absolute_url(original_url)
         return WPShortenURLPage.render_template('ursh_custom_shortener_page.html',
                                                 event=self.event,
                                                 ursh_host=self.ursh_host,
@@ -85,9 +93,15 @@ class RHCustomShortURLPage(RHManageEventBase):
                                                 submitted=False,
                                                 shortcut=None)
 
-    def _process_POST(self):
-        original_url = self._make_absolute_url(request.args['original_url'])
-        shortcut = request.form['shortcut'].strip()
+    @use_kwargs({
+        'original_url': fields.String(required=True, validate=not_empty),
+    }, location='query')
+    @use_kwargs({
+        'shortcut': fields.String(required=True, validate=not_empty),
+    })
+    def _process_POST(self, original_url, shortcut):
+        original_url = self._make_absolute_url(original_url)
+        shortcut = shortcut.strip()
 
         if not (set(shortcut) <= CUSTOM_SHORTCUT_ALPHABET):
             raise BadRequest('Invalid shortcut')

--- a/ursh/indico_ursh/templates/ursh_custom_shortener_page.html
+++ b/ursh/indico_ursh/templates/ursh_custom_shortener_page.html
@@ -34,7 +34,7 @@
             </button>
             <input id="ursh-custom-shortcut-input" name="shortcut" type="text" style="font-family:monospace;"
                    spellcheck="false" autocomplete="off" autocapitalize="off"
-                   pattern="^[0-9a-zA-Z-]{5,}$"
+                   pattern="^[0-9a-zA-Z\-]{5,}$"
                    {% if shortcut %}value="{{ shortcut }}"{% endif %}
                    placeholder="{% trans %}Enter a shortcut...{% endtrans %}">
             <button id="ursh-custom-shortcut-submit-button" type="submit" class="i-button" disabled>

--- a/ursh/pyproject.toml
+++ b/ursh/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'indico-plugin-ursh'
 description = 'URL shortening service for Indico'
 readme = 'README.md'
-version = '3.3.4'
+version = '3.3.5'
 license = 'MIT'
 authors = [{ name = 'Indico Team', email = 'indico-team@cern.ch' }]
 classifiers = [


### PR DESCRIPTION
Also fix the client-side pattern to validate custom shortcuts, for some reason browsers do not support an unescaped dash in a bracketed range, even though it's usually accepted.